### PR TITLE
Update license, document and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ df.select("author", "id").collect().foreach(println)
 
 You can manually specify the schema when reading data:
 ```scala
-import of.SQLContext
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
 
 val sqlContext = new SQLContext(sc)

--- a/README.md
+++ b/README.md
@@ -5,24 +5,10 @@ The structure and test tools are mostly copied from databricks/spark-csv.
 
 - This package supports to process format-free XML files in a distributed way, unlike JSON datasource in Spark restricts in-line JSON format.
 
-- Since this package is supposed to move under another organazation, it is not uploaded to maven yet.
 
 ## Requirements
 
 This library requires Spark 1.3+
-
-## Using with Spark shell
-This package can be added to  Spark using the `--packages` command line option.  For example, to include it when starting the spark shell:
-
-### Spark compiled with Scala 2.11
-```
-$SPARK_HOME/bin/spark-shell --packages HyukjinKwon:spark-xml:0.1.1-s_2.11
-```
-
-### Spark compiled with Scala 2.10
-```
-$SPARK_HOME/bin/spark-shell --packages HyukjinKwon:spark-xml:0.1.1-s_2.10
-```
 
 ## Features
 This package allows reading XML files in local or distributed filesystem as [Spark DataFrames](https://spark.apache.org/docs/1.3.0/sql-programming-guide.html).
@@ -37,7 +23,7 @@ When reading files the API accepts several options:
 
 The package does not support to write a Dataframe to XML file.
 
-Currently it supports the shorten name useage. You can use just `xml` instead of `org.apache.spark.sql.xml` from Spark 1.5.0+
+Currently it supports the shorten name useage. You can use just `xml` instead of `com.databricks.xml` from Spark 1.5.0+
 
 These examples use a XML file available for download [here](https://github.com/databricks/spark-xml/raw/master/src/test/resources/books.xml):
 
@@ -50,14 +36,14 @@ $ wget https://github.com/databricks/spark-xml/raw/master/src/test/resources/boo
 Spark-xml can infer data types:
 ```sql
 CREATE TABLE books
-USING org.apache.spark.sql.xml
+USING com.databricks.xml
 OPTIONS (path "books.xml", rootTag "book")
 ```
 
 You can also specify column names and types in DDL. In this case, we do not infer schema.
 ```sql
 CREATE TABLE books (author string, description string, genre string, id string, price double, publish_date string, title string)
-USING org.apache.spark.sql.xml
+USING com.databricks.xml
 OPTIONS (path "books.xml", rootTag "book")
 ```
 
@@ -69,7 +55,7 @@ import org.apache.spark.sql.SQLContext
 
 val sqlContext = new SQLContext(sc)
 val df = sqlContext.read
-    .format("org.apache.spark.sql.xml")
+    .format("com.databricks.xml")
     .option("rootTag", "book") // This should be always given.
     .load("books.xml")
 
@@ -93,7 +79,7 @@ val customSchema = StructType(
 
 
 val df = sqlContext.read
-    .format("org.apache.spark.sql.xml")
+    .format("com.databricks.xml")
     .option("rootTag", "book") // This should be always given.
     .schema(customSchema)
     .load("books.xml")
@@ -109,7 +95,7 @@ import org.apache.spark.sql.SQLContext
 
 val sqlContext = new SQLContext(sc)
 val df = sqlContext.load(
-    "org.apache.spark.sql.xml", 
+    "com.databricks.xml",
     Map("path" -> "books.xml", "rootTag" -> "book"))
 
 df.select("author", "id").collect().foreach(println)
@@ -117,7 +103,7 @@ df.select("author", "id").collect().foreach(println)
 
 You can manually specify the schema when reading data:
 ```scala
-import org.apache.spark.sql.SQLContext
+import of.SQLContext
 import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
 
 val sqlContext = new SQLContext(sc)
@@ -131,7 +117,7 @@ val customSchema = StructType(
     StructField("title", StringType, nullable = true))
 
 val df = sqlContext.load(
-    "org.apache.spark.sql.xml", 
+    "com.databricks.xml",
     schema = customSchema,
     Map("path" -> "books.xml", "rootTag" -> "book"))
 
@@ -146,7 +132,7 @@ import org.apache.spark.sql.SQLContext
 
 SQLContext sqlContext = new SQLContext(sc);
 DataFrame df = sqlContext.read()
-    .format("org.apache.spark.sql.xml")
+    .format("com.databricks.xml")
     .option("rootTag", "book")
     .load("books.xml");
 
@@ -169,7 +155,7 @@ StructType customSchema = new StructType(
     new StructField("title", StringType, true));
 
 DataFrame df = sqlContext.read()
-    .format("org.apache.spark.sql.xml")
+    .format("com.databricks.xml")
     .option("rootTag", "book")
     .schema(customSchema)
     .load("books.xml");
@@ -190,7 +176,7 @@ HashMap<String, String> options = new HashMap<String, String>();
 options.put("rootTag", "book");
 options.put("path", "books.xml");
 
-DataFrame df = sqlContext.load("org.apache.spark.sql.xml", options);
+DataFrame df = sqlContext.load("com.databricks.xml", options);
 df.select("author", "id").collect();
 ```
 
@@ -213,7 +199,7 @@ HashMap<String, String> options = new HashMap<String, String>();
 options.put("rootTag", "book");
 options.put("path", "books.xml");
 
-DataFrame df = sqlContext.load("org.apache.spark.sql.xml", customSchema, options);
+DataFrame df = sqlContext.load("com.databricks.xml", customSchema, options);
 df.select("author", "id").collect();
 ```
 
@@ -225,7 +211,7 @@ __Spark 1.4+:__
 from pyspark.sql import SQLContext
 sqlContext = SQLContext(sc)
 
-df = sqlContext.read.format('org.apache.spark.sql.xml').options(rootTag='book').load('books.xml')
+df = sqlContext.read.format('com.databricks.xml').options(rootTag='book').load('books.xml')
 df.select("author", "id").collect()
 ```
 
@@ -245,7 +231,7 @@ customSchema = StructType([ \
     StructField("title", StringType(), True])) \
 
 df = sqlContext.read \
-    .format('org.apache.spark.sql.xml') \
+    .format('com.databricks.xml') \
     .options(rootTag='book') \
     .load('books.xml', schema = customSchema)
 
@@ -286,5 +272,5 @@ This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line
 
 ## Acknowledgements
 
-This project was initially created by @HyukjinKwon and donated to Databricks.
+This project was initially created by [HyukjinKwon](https://github.com/HyukjinKwon) and donated to [Databricks](https://databricks.com).
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ name := "spark-xml"
 
 version := "0.1.2"
 
-organization := "HyukjinKwon"
+organization := "com.databricks"
 
 scalaVersion := "2.11.7"
 
-spName := "HyukjinKwon/spark-xml"
+spName := "databricks/spark-xml"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 
@@ -41,7 +41,7 @@ spAppendScalaVersion := true
 spIncludeMaven := true
 
 pomExtra := (
-  <url>https://github.com/HyukjinKwon/spark-xml</url>
+  <url>https://github.com/databricks/spark-xml</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -50,8 +50,8 @@ pomExtra := (
     </license>
   </licenses>
   <scm>
-    <url>git@github.com:HyukjinKwon/spark-xml.git</url>
-    <connection>scm:git:git@github.com:HyukjinKwon/spark-xml.git</connection>
+    <url>git@github.com:databricks/spark-xml.git</url>
+    <connection>scm:git:git@github.com:databricks/spark-xml.git</connection>
   </scm>
   <developers>
     <developer>

--- a/src/main/java/com/databricks/hadoop/mapreduce/lib/input/XmlInputFormat.java
+++ b/src/main/java/com/databricks/hadoop/mapreduce/lib/input/XmlInputFormat.java
@@ -1,10 +1,9 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource15.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource15.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/util/ParseModes.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/ParseModes.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/databricks/spark/xml/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/xml/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Apache
+ * Copyright 2014 Databricks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/databricks/spark/xml/parsers/dom/DomXmlParserSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/dom/DomXmlParserSuite.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.databricks.spark.xml.parsers.dom
 
 import org.scalatest.FunSuite

--- a/src/test/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParserSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParserSuite.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2014 Databricks
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
In this PR, I changed the license, the document and organizations written at `build.sbt`.
Probably I should have made each PR separately but I just did this as there are no other PRs except mine currently.

1. As the package name has been renamed, I updated the document and removed **Using with Spark shell** instruction because that would not work as the examples below in README.md due to the package name. I will get this back as soon as I make this work properly and check if this package is available via `--packages`. 

2. Updated license comments.

3. Changed the organizations at `build.sbt`