### PR TITLE
apply in an companion object probably should return the object of the companion class.

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -48,8 +48,8 @@ case class XmlRelation protected[spark] (
 
   override val schema: StructType = {
     Option(userSchema).getOrElse {
-      InferSchema(
-        DomXmlPartialSchemaParser(
+      InferSchema.infer(
+        DomXmlPartialSchemaParser.parse(
           baseRDD(),
           samplingRatio,
           parseMode,
@@ -59,7 +59,7 @@ case class XmlRelation protected[spark] (
   }
 
   override def buildScan: RDD[Row] = {
-    DomXmlParser(
+    DomXmlParser.parse(
       baseRDD(),
       schema,
       parseMode,

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
@@ -146,7 +146,7 @@ private[xml] object DomXmlParser {
   val OBJECT: Int = 6
   val ARRAY: Int = 7
 
-  def apply(xml: RDD[String],
+  def parse(xml: RDD[String],
             schema: StructType,
             parseMode: String,
             excludeAttributeFlag: Boolean,

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
@@ -33,7 +33,7 @@ import com.databricks.spark.xml.util.InferSchema
  */
 
 private[xml] object DomXmlPartialSchemaParser {
-  def apply(xml: RDD[String],
+  def parse(xml: RDD[String],
             samplingRatio: Double,
             parseMode: String,
             excludeAttributeFlag: Boolean,

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -49,7 +49,7 @@ private[xml] object InferSchema {
    *   2. Merge types by choosing the lowest type necessary to cover equal keys
    *   3. Replace any remaining null fields with string, the top type
    */
-  def apply(partialSchema: RDD[DataType]): StructType = {
+  def infer(partialSchema: RDD[DataType]): StructType = {
     // perform schema inference on each row and merge afterwards
     val rootType = partialSchema
       .treeAggregate[DataType](StructType(Seq()))(compatibleRootType, compatibleRootType)


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/10

According to [Databricks Scala style](https://github.com/HyukjinKwon/scala-style-guide/blob/master/README.md#apply_method),  `apply()` of an companion object would better just return the object of the  companion class. However, the objects of `InferSchema`, `DomXmlParser` and `DomXmlPartialSchemaParser` are not doing this.

I changed the function names correspondingly with Spark JSON datasource (`InferSchema` and `JacksonParser`).