### PR TITLE
Add some tests for excludeAttribute and treatEmptyValuesAsNulls option

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -54,7 +54,7 @@ class XmlReader extends Serializable {
     this
   }
 
-  def withIncludeAttributeFlag(exclude: Boolean): XmlReader = {
+  def withExcludeAttributeFlag(exclude: Boolean): XmlReader = {
     this.excludeAttributeFlag = exclude
     this
   }

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -54,7 +54,7 @@ class XmlReader extends Serializable {
     this
   }
 
-  def withExcludeAttributeFlag(exclude: Boolean): XmlReader = {
+  def withExcludeAttribute(exclude: Boolean): XmlReader = {
     this.excludeAttributeFlag = exclude
     this
   }

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
@@ -175,16 +175,16 @@ private[xml] object DomXmlParser {
    */
 
   private[xml] def convertField(node: Node,
-                                schema: DataType,
+                                dataType: DataType,
                                 conf: DomConfiguration ): Any = {
+    val shouldBeNullValue = node.getTextContent == null ||
+      node.getTextContent.size <= 0 && conf.treatEmptyValuesAsNulls
 
-    // TODO: Here we can decide if it treats spaces as null value or not for data
-    if (node.getTextContent == null) {
+    if (shouldBeNullValue) {
       null
-    } else if (node.getTextContent.length <= 0) {
-      null
-    } else {
-      schema match {
+    }
+    else {
+      dataType match {
         case LongType =>
           signSafeToLong(node.getTextContent)
 
@@ -256,8 +256,8 @@ private[xml] object DomXmlParser {
     val row = new Array[Any](schema.length)
     parser.foreach{ node =>
       val field = node.getNodeName
-      schema.map(_.name).zipWithIndex
-        .toMap.get(field) match {
+      val nameToIndex = schema.map(_.name).zipWithIndex.toMap
+      nameToIndex.get(field) match {
         case Some(index) =>
           // For XML, it can contains the same keys.
           // So we need to manually merge them to an array.

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -266,7 +266,7 @@ abstract class AbstractXmlSuite extends FunSuite with BeforeAndAfterAll {
 
   test("DSL test schema (excluding tags) inferred correctly") {
     val results = new XmlReader()
-      .withExcludeAttributeFlag(true)
+      .withExcludeAttribute(true)
       .withRootTag(booksFileTag)
       .xmlFile(sqlContext, booksFile)
 

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -264,6 +264,24 @@ abstract class AbstractXmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.collect().size === numBooksComplicated)
   }
 
+  test("DSL test schema (excluding tags) inferred correctly") {
+    val results = new XmlReader()
+      .withExcludeAttributeFlag(true)
+      .withRootTag(booksFileTag)
+      .xmlFile(sqlContext, booksFile)
+
+    val schema = StructType(List(
+      StructField("author", StringType, nullable = true),
+      StructField("description", StringType, nullable = true),
+      StructField("genre", StringType, nullable = true),
+      StructField("price", DoubleType, nullable = true),
+      StructField("publish_date", StringType, nullable = true),
+      StructField("title", StringType, nullable = true))
+    )
+
+    assert(results.schema === schema)
+  }
+
   test("DSL test with different data types") {
     val stringSchema = new StructType(
       Array(
@@ -297,14 +315,26 @@ abstract class AbstractXmlSuite extends FunSuite with BeforeAndAfterAll {
   test("DSL test nullable fields") {
     val results = new XmlReader()
       .withSchema(StructType(List(StructField("name", StringType, false),
-                                  StructField("age", IntegerType, true))))
+                                  StructField("age", StringType, true))))
       .withRootTag(nullNumbersFileTag)
       .xmlFile(sqlContext, nullNumbersFile)
       .collect()
 
-    assert(results.head.toSeq === Seq("alice", 35))
+    assert(results.head.toSeq === Seq("alice", "35"))
+    assert(results(1).toSeq === Seq("bob", ""))
+    assert(results(2).toSeq === Seq("coc", "24"))
+  }
+
+  test("DSL test for treating empty string as null value") {
+    val results = new XmlReader()
+      .withSchema(StructType(List(StructField("name", StringType, false),
+      StructField("age", IntegerType, true))))
+      .withRootTag(nullNumbersFileTag)
+      .withTreatEmptyValuesAsNulls(true)
+      .xmlFile(sqlContext, nullNumbersFile)
+      .collect()
+
     assert(results(1).toSeq === Seq("bob", null))
-    assert(results(2).toSeq === Seq("coc", 24))
   }
 }
 


### PR DESCRIPTION
Currently, the options `excludeAttribute` and `treatEmptyValuesAsNulls` are not being tested correctly.

Also, `treatEmptyValuesAsNulls` option was actually not being working.

In this PR, I added the tests for both and made `treatEmptyValuesAsNulls` actually  working.