### PR TITLE
Support for inferring more promitive datatypes.

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlParser.scala
@@ -112,11 +112,15 @@ private[xml] class DomXmlParser(doc: Node, conf: DomConfiguration = DomConfigura
     } else if (data == null) {
       NULL
     } else if (isLong(data)) {
+      INTEGER
+    } else if (isLong(data)) {
       LONG
     } else if (isDouble(data)) {
       DOUBLE
     } else if (isBoolean(data)) {
       BOOLEAN
+    } else if (isTimestamp(data)){
+      TIMESTAMP
     } else {
       STRING
     }
@@ -140,11 +144,13 @@ private[xml] object DomXmlParser {
   val FAIL: Int = -1
   val NULL: Int = 1
   val BOOLEAN: Int = 2
-  val LONG: Int = 3
-  val DOUBLE: Int = 4
-  val STRING: Int = 5
-  val OBJECT: Int = 6
-  val ARRAY: Int = 7
+  val INTEGER: Int = 3
+  val LONG: Int = 4
+  val DOUBLE: Int = 5
+  val STRING: Int = 6
+  val TIMESTAMP: Int = 7
+  val OBJECT: Int = 8
+  val ARRAY: Int = 9
 
   def parse(xml: RDD[String],
             schema: StructType,

--- a/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/dom/DomXmlPartialSchemaParser.scala
@@ -85,6 +85,9 @@ private[xml] object DomXmlPartialSchemaParser {
                          conf: DomConfiguration): DataType = {
     import com.databricks.spark.xml.parsers.dom.DomXmlParser._
     dataType match {
+      case INTEGER =>
+        LongType
+
       case LONG =>
         LongType
 
@@ -99,6 +102,9 @@ private[xml] object DomXmlPartialSchemaParser {
 
       case NULL =>
         NullType
+
+      case TIMESTAMP =>
+        TimestampType
 
       case OBJECT =>
         inferObject(new DomXmlParser(node, conf))

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -20,15 +20,20 @@ import org.apache.spark.sql.types._
 
 private[xml] object InferSchema {
 
-  // Both vals below brought from HiveTypeCoercion just for version compatibility
-  private val numericPrecedence =
-    IndexedSeq(
+  /**
+   * Copied from internal Spark api
+   * [[org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion]]
+   */
+  private val numericPrecedence: IndexedSeq[DataType] =
+    IndexedSeq[DataType](
       ByteType,
       ShortType,
       IntegerType,
       LongType,
       FloatType,
-      DoubleType)
+      DoubleType,
+      TimestampType,
+      DecimalType.Unlimited)
 
   val findTightestCommonTypeOfTwo: (DataType, DataType) => Option[DataType] = {
     case (t1, t2) if t1 == t2 => Some(t1)

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -21,6 +21,7 @@ import java.text.NumberFormat
 import java.util.Locale
 
 import scala.util.Try
+import scala.util.control.Exception._
 
 import org.apache.spark.sql.types._
 
@@ -114,13 +115,16 @@ object TypeCast {
     } else {
       value
     }
-    try {
-      signSafeValue.toDouble
-      true
-    } catch {
-      case e: NumberFormatException =>
-        false
+    (allCatch opt signSafeValue.toDouble).isDefined
+  }
+
+  private[xml] def isInteger(value: String): Boolean = {
+    val signSafeValue: String = if (value.startsWith("+") || value.startsWith("-")) {
+      value.substring(1)
+    } else {
+      value
     }
+    (allCatch opt signSafeValue.toInt).isDefined
   }
 
   private[xml] def isLong(value: String): Boolean = {
@@ -129,13 +133,11 @@ object TypeCast {
     } else {
       value
     }
-    try {
-      signSafeValue.toLong
-      true
-    } catch {
-      case e: NumberFormatException =>
-        false
-    }
+    (allCatch opt signSafeValue.toLong).isDefined
+  }
+
+  private[xml] def isTimestamp(value: String): Boolean = {
+    (allCatch opt Timestamp.valueOf(value)).isDefined
   }
 
   private[xml] def signSafeToLong(value: String): Long = {

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -97,8 +97,11 @@ class TypeCastSuite extends FunSuite {
 
   test("Types with sign are checked correctly") {
     assert(TypeCast.isBoolean("true"))
+    assert(TypeCast.isInteger("10"))
     assert(TypeCast.isLong("10"))
     assert(TypeCast.isDouble("+10.1"))
+    val timestamp = "2015-01-01 00:00:00"
+    assert(TypeCast.isTimestamp(timestamp))
   }
 
   test("Float and Double Types are cast correctly with Locale") {


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/27
Currently this library infers primitive datatypes `DoubleType`, `LongType`, `StringType`, `BooleanType` and`NullType`.

In this PR, `IntegerType` ,`TimestampType` can be inferred.