### PR TITLE
Use different indentation writer and not test with Hadoop 1.x and Spark 1.4.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,15 @@ matrix:
       scala: 2.11.7
       env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.3.0"
     # Spark 1.4.1
+    # We only test Spark 1.4.1 with Hadooop 2.2.0 because
+    # https://github.com/apache/spark/pull/6599 is not present in 1.4.1,
+    # so the published Spark Maven artifacts will not work with Hadoop 1.x.
     - jdk: openjdk6
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.4.1"
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.4.1"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     # Spark 1.5.0
     - jdk: openjdk7
       scala: 2.10.5

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -20,7 +20,7 @@ import javax.xml.stream.XMLOutputFactory
 
 import scala.collection.Map
 
-import com.sun.xml.txw2.output.IndentingXMLStreamWriter
+import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql.{DataFrame, SQLContext}

--- a/src/main/scala/com/databricks/spark/xml/parsers/stax/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/stax/StaxXmlGenerator.scala
@@ -17,7 +17,7 @@ package com.databricks.spark.xml.parsers.stax
 
 import scala.collection.Map
 
-import com.sun.xml.txw2.output.IndentingXMLStreamWriter
+import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._


### PR DESCRIPTION
`com.sun.xml.txw2.output.IndentingXMLStreamWriter` does not existing in some lower JDK. I changed this to `com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter`

It only tests Spark 1.4.1 with Hadooop 2.2.0 due to the issue SPARK-8057.