### PR TITLE
Polishing tests to remove useless variables and duplicated variables.

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -42,7 +42,6 @@ package object xml {
                  failFastFlag: Boolean = false,
                  charset: String = XmlFile.DEFAULT_CHARSET.name()): DataFrame = {
 
-
       val xmlRelation = XmlRelation(
         () => XmlFile.withCharset(sqlContext.sparkContext, filePath, charset, rowTag),
         location = Some(filePath),


### PR DESCRIPTION
In this PR, I removed some useless newlines, variables and duplicated variables having the same value.

Now that the options `rowTag` and `rootTag` have the default values, `ROW` and `ROWS` in this library, I removed setting the options in some tests.

Also, the `rowTag`, `book`, can be shared instead of defining that for each file. 
It looks the functionality of `rowTag` and `rootTag` can be tested on some so it would be safe to remove others.