### PR TITLE
Attributes in elements having no child element are not inferred and read.

### DIFF
--- a/src/test/resources/books-attributes-in-non-nested.xml
+++ b/src/test/resources/books-attributes-in-non-nested.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <price unit="$">44.95</price>
+      <publish_date>2000-10-01</publish_date>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <price unit="$">5.95</price>
+      <publish_date>2000-12-16</publish_date>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <price unit="$">5.95</price>
+      <publish_date>2000-11-17</publish_date>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <price unit="$">5.95</price>
+      <publish_date>2001-03-10</publish_date>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <price unit="$">5.95</price>
+      <publish_date>2001-09-10</publish_date>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <price unit="$">4.95</price>
+      <publish_date>2000-09-02</publish_date>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <price unit="$">4.95</price>
+      <publish_date>2000-11-02</publish_date>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <price unit="$">4.95</price>
+      <publish_date>2000-12-06</publish_date>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <price unit="$">6.95</price>
+      <publish_date>2000-11-02</publish_date>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <price unit="$">36.95</price>
+      <publish_date>2000-12-09</publish_date>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <price unit="$">36.95</price>
+      <publish_date>2000-12-01</publish_date>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <price unit="$">49.95</price>
+      <publish_date>2001-04-16</publish_date>
+   </book>
+</catalog>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -406,7 +406,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.collect().size === numBooksComplicated)
   }
 
-  test("DSL test parsing and inferring attribute in non-nested elements") {
+  test("DSL test parsing and inferring attribute in elements having no child element") {
     val results = new XmlReader()
       .withRowTag(booksTag)
       .xmlFile(sqlContext, booksAttributesInNonNestedFile)

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -32,6 +32,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val booksFile = "src/test/resources/books.xml"
   val booksNestedObjectFile = "src/test/resources/books-nested-object.xml"
   val booksNestedArrayFile = "src/test/resources/books-nested-array.xml"
+  val booksAttributesInNonNestedFile = "src/test/resources/books-attributes-in-non-nested.xml"
   val booksComplicatedFile = "src/test/resources/books-complicated.xml"
   val carsFile = "src/test/resources/cars.xml"
   val carsUnbalancedFile = "src/test/resources/cars-unbalanced-elements.xml"
@@ -403,6 +404,26 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     ))
 
     assert(results.collect().size === numBooksComplicated)
+  }
+
+  test("DSL test parsing and inferring attribute in non-nested elements") {
+    val results = new XmlReader()
+      .withRowTag(booksTag)
+      .xmlFile(sqlContext, booksAttributesInNonNestedFile)
+
+    val schema = StructType(List(
+      StructField("author", StringType, nullable = true),
+      StructField("id", StringType, nullable = true),
+      StructField("price", StructType(
+        List(StructField("price", DoubleType, nullable = true),
+          StructField("unit", StringType, nullable = true))),
+        nullable = true),
+      StructField("publish_date", StringType, nullable = true),
+      StructField("title", StringType, nullable = true))
+    )
+
+    assert(results.schema === schema)
+    assert(results.count == numBooks)
   }
 
   test("DSL test schema (excluding tags) inferred correctly") {


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/39

This PR makes this library can rest attributes in non-nested elements.

If there are XML files below, it make dataframes with the schemas as below:

- Attributes in element that has nested child elements

    ```xml
    ...
    <one myOneAttrib="AAAA">
        <two>two</two>
        <three>three</three>
    </one>
    ...
    ```
produces the schema below:

    ```
    root
     |-- myOneAttrib: string (nullable = true)
     |-- two: string (nullable = true)
     |-- three: string (nullable = true)
    ```

- Attributes in element that has non-nested child elements

    ```xml
    ...
    <one>
        <two myTwoAttrib="BBBBB">two</two>
        <three>three</three>
    </one>
    ...
    ```
produces the schema below:
    ```
    root
     |-- two: struct (nullable = true)
     |    |-- two: string (nullable = true)
     |    |-- myTwoAttrib: string (nullable = true)
     |-- three: string (nullable = true)
    ```
