### PR TITLE
Test against Spark 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,13 @@ matrix:
     - jdk: openjdk7
       scala: 2.11.7
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0"
+    # Spark 1.6.0
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.6.0"
+    - jdk: openjdk7
+      scala: 2.11.7
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION assembly

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ spName := "databricks/spark-xml"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 
-sparkVersion := "1.5.0"
+sparkVersion := "1.6.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 


### PR DESCRIPTION
#44 
Since [Spark 1.6.0](http://spark.apache.org/docs/1.6.0/) is released and this still stays as a third-party library, I think it would be better to test against Spark 1.6.0.
Fortunately, this looks testing fine with this version.