### PR TITLE
Support for pruned scan for required fields. 

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -61,12 +61,12 @@ case class XmlRelation protected[spark] (
     val schemaFields = schema.fields
     if (schemaFields.deep == requiredFields.deep) {
       buildScan()
-    } else if (parseConf.failFastFlag) {
+    } else if (options.failFastFlag) {
       val safeRequestedSchema = StructType(requiredFields)
       StaxXmlParser.parse(
         baseRDD(),
         safeRequestedSchema,
-        parseConf)
+        options)
     } else {
       // If `failFast` is disabled, then it needs to parse all the values
       // so that we can decide which row is malformed.
@@ -75,7 +75,7 @@ case class XmlRelation protected[spark] (
       val rows = StaxXmlParser.parse(
         baseRDD(),
         safeRequestedSchema,
-        parseConf)
+        options)
 
       val rowSize = requiredFields.length
       rows.mapPartitions { iter =>

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -80,7 +80,7 @@ case class XmlRelation protected[spark] (
         safeRequestedSchema,
         parseConf)
     } else {
-      // If `parseConf` is disabled, then it needs to parse all the values
+      // If `failFast` is disabled, then it needs to parse all the values
       // so that we can decide which row is malformed.
       val safeRequestedSchema = StructType(
         requiredFields ++ schema.fields.filterNot(requiredFields.contains(_)))

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -76,8 +76,8 @@ case class XmlRelation protected[spark] (
       buildScan
     } else {
       val safeRequiredFields = if (!parseConf.failFastFlag) {
-        // If `parseConf` is disabled, then it needs to parse all the values
-        // so that we can decide which row is malformed.
+        // If `failFast` is disabled, then it needs to parse all the values
+        // so that we can drop malformed rows.
         requiredFields ++ schemaFields.filterNot(requiredFields.contains(_))
       } else {
         requiredFields

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -206,16 +206,16 @@ private[xml] object StaxXmlParser {
    */
   private def convertValues(valuesMap: Map[String, String],
                             schema: StructType): Map[String, Any] = {
-    val target = collection.mutable.Map.empty[String, Any]
+    val convertedValuesMap = collection.mutable.Map.empty[String, Any]
     valuesMap.foreach {
       case (f, v) =>
         val nameToIndex = schema.map(_.name).zipWithIndex.toMap
         nameToIndex.get(f).foreach {
           case i =>
-            target(f) = convertStringTo(v, schema(i).dataType)
+            convertedValuesMap(f) = convertStringTo(v, schema(i).dataType)
         }
     }
-    Map(target.toSeq: _*)
+    Map(convertedValuesMap.toSeq: _*)
   }
 
   /**

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -210,12 +210,9 @@ private[xml] object StaxXmlParser {
     valuesMap.foreach {
       case (f, v) =>
         val nameToIndex = schema.map(_.name).zipWithIndex.toMap
-        nameToIndex.get(f) match {
-          case Some(i) =>
+        nameToIndex.get(f).foreach {
+          case i =>
             target(f) = convertStringTo(v, schema(i).dataType)
-          case _ =>
-            // This will eventually emits `XMLStreamException`.
-            logger.error(s"The field ('$f') does not exist in schema")
         }
     }
     Map(target.toSeq: _*)
@@ -253,8 +250,8 @@ private[xml] object StaxXmlParser {
           val attributes = e.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           // Set elements and other attributes to the row
           val field = e.asStartElement.getName.getLocalPart
-          nameToIndex.get(field) match {
-            case Some(index) =>
+          nameToIndex.get(field).foreach {
+            case index =>
               val dataType = schema(index).dataType
               dataType match {
                 case st: StructType if st.exists(_.name == conf.valueTag) =>
@@ -290,9 +287,6 @@ private[xml] object StaxXmlParser {
                 case _ =>
                   row(index) = convertField(parser, dataType, conf)
               }
-            case _ =>
-              // This will eventually emits `XMLStreamException`.
-              logger.error(s"The field ('$field') does not exist in schema")
           }
         case _: EndElement =>
           shouldStop = checkEndElement(parser, conf)

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -86,9 +86,11 @@ private[xml] object InferSchema {
         val reader = new ByteArrayInputStream(xml.getBytes)
         val parser = factory.createXMLEventReader(reader)
         try {
-          val rootEvent = skipUntil(parser, XMLStreamConstants.START_ELEMENT)
-          val rootAttributes = rootEvent.asStartElement.getAttributes
-            .map(_.asInstanceOf[Attribute]).toArray
+          val rootAttributes = {
+            val rootEvent = skipUntil(parser, XMLStreamConstants.START_ELEMENT)
+            rootEvent.asStartElement.getAttributes
+              .map(_.asInstanceOf[Attribute]).toArray
+          }
           Some(inferObject(parser, conf, rootAttributes))
         } catch {
           case _: java.lang.NumberFormatException if !failFast =>

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -18,6 +18,7 @@ package com.databricks.spark.xml;
 import java.io.File;
 import java.util.HashMap;
 
+import com.databricks.spark.xml.util.XmlFile;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,7 +26,6 @@ import org.junit.Test;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
-import com.databricks.spark.xml.util.XmlFile;
 
 public class JavaXmlSuite {
     private transient SQLContext sqlContext;

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -18,7 +18,6 @@ package com.databricks.spark.xml;
 import java.io.File;
 import java.util.HashMap;
 
-import com.databricks.spark.xml.util.XmlFile;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +25,7 @@ import org.junit.Test;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
+import com.databricks.spark.xml.util.XmlFile;
 
 public class JavaXmlSuite {
     private transient SQLContext sqlContext;

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -187,7 +187,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .xmlFile(sqlContext, carsUnbalancedFile)
       .count()
 
-    assert(results === 3)
+    assert(results === numCars)
   }
 
   test("DDL test with empty file") {
@@ -463,7 +463,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .xmlFile(sqlContext, carsUnbalancedFile)
       .count()
 
-    assert(results === 3)
+    assert(results === numCars)
   }
 
   test("DSL test inferred schema passed through") {


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/21
This library will read all data but does not have to check all the values in rows and convert (cast) them all.
This PR adds the feature for pruned scan for this.

For the reason similar with https://github.com/databricks/spark-csv/issues/219, this should parse all when dropping rows. This PR is similar with https://github.com/databricks/spark-csv/pull/169.

I did not add a test for this as it looks existing tests covers this.