### PR TITLE
Change the inappropriate message when failing to parse TimestampType and DateType.

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -35,7 +35,6 @@ package object xml {
   implicit class XmlContext(sqlContext: SQLContext) extends Serializable {
     def xmlFile(
                  filePath: String,
-                 mode: String = "PERMISSIVE",
                  rowTag: String = XmlFile.DEFAULT_ROW_TAG,
                  samplingRatio: Double = 1.0,
                  excludeAttributeFlag: Boolean = false,

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -67,11 +67,11 @@ private[xml] object StaxXmlParser {
             .map(_.asInstanceOf[Attribute]).toArray
           Some(convertObject(parser, schema, conf, rootAttributes))
         } catch {
-          case _: java.lang.NumberFormatException | _: IllegalArgumentException if !failFast =>
+          case _: java.lang.NumberFormatException if !failFast =>
             logger.warn("Number format exception. " +
               s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
             None
-          case _: java.text.ParseException if !failFast =>
+          case _: java.text.ParseException | _: IllegalArgumentException  if !failFast =>
             logger.warn("Parse exception. " +
               s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
             None

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -91,11 +91,11 @@ private[xml] object InferSchema {
             .map(_.asInstanceOf[Attribute]).toArray
           Some(inferObject(parser, conf, rootAttributes))
         } catch {
-          case _: java.lang.NumberFormatException | _: IllegalArgumentException if !failFast =>
+          case _: java.lang.NumberFormatException if !failFast =>
             logger.warn("Number format exception. " +
               s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
             None
-          case _: java.text.ParseException if !failFast =>
+          case _: java.text.ParseException | _: IllegalArgumentException if !failFast =>
             logger.warn("Parse exception. " +
               s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
             None

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -18,7 +18,6 @@ package com.databricks.spark.xml;
 import java.io.File;
 import java.util.HashMap;
 
-import com.databricks.spark.xml.util.XmlFile;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +25,7 @@ import org.junit.Test;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
+import com.databricks.spark.xml.util.XmlFile;
 
 public class JavaXmlSuite {
     private transient SQLContext sqlContext;


### PR DESCRIPTION
When failing to parse `TimestampType` and `DateType`, it emits `IllegalArgumentException`. In this PR, it moved the exception to parsing exception.

