### PR TITLE
Add description for structure conversion in reading and writing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ When writing files the API accepts several options:
 
 Currently it supports the shorten name useage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
 
-These examples use a XML file available for download [here](https://github.com/databricks/spark-xml/raw/master/src/test/resources/books.xml):
-
-```
-$ wget https://github.com/databricks/spark-xml/raw/master/src/test/resources/books.xml
-```
-
-
 ## Structure Conversion
 
 Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that hanlding attributes can be disbaled with the option `excludeAttribute`.
@@ -143,6 +136,12 @@ Due to the structure differences between `DataFrame` and XML files, there are so
 
 
 ## Examples
+
+These examples use a XML file available for download [here](https://github.com/databricks/spark-xml/raw/master/src/test/resources/books.xml):
+
+```
+$ wget https://github.com/databricks/spark-xml/raw/master/src/test/resources/books.xml
+```
 
 ### SQL API
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Due to the structure differences between `DataFrame` and XML files, there are so
 
     with the data below:
     ```
-    +--------------------+
-    |                   a|
-    +--------------------+
-    |[WrappedArray(aa,bb)|
-    +--------------------+
+    +------------------------------------+
+    |                                   a|
+    +------------------------------------+
+    |[WrappedArray(aa), WrappedArray(bb)]|
+    +------------------------------------+
     ```
 
     produces a XML file below:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ wget https://github.com/databricks/spark-xml/raw/master/src/test/resources/boo
 
 ## Structure Conversion
 
-Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that the attributes hanlding can be disbaled with the option `excludeAttribute`.
+Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that hanlding attributes can be disbaled with the option `excludeAttribute`.
 
 
 ### Reading from XML to `DataFrame`
@@ -134,6 +134,8 @@ Due to the structure differences between `DataFrame` and XML files, there are so
     ...
     <a>
         <item>aa</item>
+    </a>
+    <a>
         <item>bb</item>
     </a>
     ...

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package allows reading XML files in local or distributed filesystem as [Spa
 When reading files the API accepts several options:
 * `path`: Location of files. Similar to Spark can accept standard Hadoop globbing expressions.
 * `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
-* `samplingRatio`: Sampling ratio for inferring schema (0.0 ~ 1). Default is 1. Possible types are `StructType`, `ArrayType`, `StringType`, `LongType`, `DoubleType` and `NullType`, unless user provides a schema for this.
+* `samplingRatio`: Sampling ratio for inferring schema (0.0 ~ 1). Default is 1. Possible types are `StructType`, `ArrayType`, `StringType`, `LongType`, `DoubleType`, `BooleanType`, `TimestampType` and `NullType`, unless user provides a schema for this.
 * `excludeAttribute` : Whether you want to exclude tags of elements as fields or not. Default is false.
 * `treatEmptyValuesAsNulls` : Whether you want to treat whitespaces as a null value. Default is false.
 * `failFast` : Whether you want to fail when it fails to parse malformed rows in XML files, instead of dropping the rows. Default is false.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Currently it supports the shorten name useage. You can use just `xml` instead of
 Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that hanlding attributes can be disbaled with the option `excludeAttribute`.
 
 
-### Reading from XML to `DataFrame`
+### Conversion from XML to `DataFrame`
 
 - __Attributes__: Attributes are converted as fields with heading prefix `attributePrefix`.
 
@@ -102,7 +102,7 @@ Due to the structure differences between `DataFrame` and XML files, there are so
      |-- three: string (nullable = true)
     ```
 
-### Writing from `DataFrame` to XML
+### Conversion from `DataFrame` to XML
 
 - __Array as an element in an array__:  Writing a XML file from `DataFrame` having a field `ArrayType` with its element as `ArrayType` would have an additional nested field for the element. This would not happen in reading and writing XML data but writing a `DataFrame` read from other sources. Therefore, roundtrip in reading and writing XML files has the same structure but writing a `DataFrame` read from other sources is possible to have a different structure.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Due to the structure differences between `DataFrame` and XML, there are some con
     </one>
     ...
     ```
-    produces the schema below:
+    produces a schema below:
     ```
     root
      |-- two: struct (nullable = true)

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Currently it supports the shorten name useage. You can use just `xml` instead of
 
 ## Structure Conversion
 
-Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that hanlding attributes can be disbaled with the option `excludeAttribute`.
+Due to the structure differences between `DataFrame` and XML, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. Note that hanlding attributes can be disbaled with the option `excludeAttribute`.
 
 
 ### Conversion from XML to `DataFrame`
 
-- __Attributes__: Attributes are converted as fields with heading prefix `attributePrefix`.
+- __Attributes__: Attributes are converted as fields with the heading prefix, `attributePrefix`.
 
     ```xml
     ...
@@ -74,7 +74,7 @@ Due to the structure differences between `DataFrame` and XML files, there are so
     </one>
     ...
     ```
-    produces the schema below:
+    produces a schema below:
 
     ```
     root
@@ -83,7 +83,7 @@ Due to the structure differences between `DataFrame` and XML files, there are so
      |-- three: string (nullable = true)
     ```
 
-- __Value in element that has no child elements but attributes__: The value is put in a separate field `valueTag`.
+- __Value in an element that has no child elements but attributes__: The value is put in a separate field, `valueTag`.
 
     ```xml
     ...
@@ -104,16 +104,16 @@ Due to the structure differences between `DataFrame` and XML files, there are so
 
 ### Conversion from `DataFrame` to XML
 
-- __Array as an element in an array__:  Writing a XML file from `DataFrame` having a field `ArrayType` with its element as `ArrayType` would have an additional nested field for the element. This would not happen in reading and writing XML data but writing a `DataFrame` read from other sources. Therefore, roundtrip in reading and writing XML files has the same structure but writing a `DataFrame` read from other sources is possible to have a different structure.
+- __Element as an array in an array__:  Writing a XML file from `DataFrame` having a field `ArrayType` with its element as `ArrayType` would have an additional nested field for the element. This would not happen in reading and writing XML data but writing a `DataFrame` read from other sources. Therefore, roundtrip in reading and writing XML files has the same structure but writing a `DataFrame` read from other sources is possible to have a different structure.
 
-    `DataFrame` with the schema below:
+    `DataFrame` with a schema below:
     ```
      |-- a: array (nullable = true)
      |    |-- element: array (containsNull = true)
      |    |    |-- element: string (containsNull = true)
     ```
 
-    with the data below:
+    with data below:
     ```
     +------------------------------------+
     |                                   a|

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -72,6 +72,8 @@ package object xml {
     //
     //   <fieldA>
     //       <item>data1</item>
+    //   </fieldA>
+    //   <fieldA>
     //       <item>data2</item>
     //   </fieldA>
     //


### PR DESCRIPTION
Due to the structure differences between `DataFrame` and XML files, there are some conversion rules from XML data to `DataFrame` and from `DataFrame` to XML data. 

I am often asked for handling attributes and writing via email. So this PR describes this in the `README.md`.