### PR TITLE
Support for different encodings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ When reading files the API accepts several options:
 * `failFast` : Whether you want to fail when it fails to parse malformed rows in XML files, instead of dropping the rows. Default is false.
 * `attributePrefix`: The prefix for attributes so that we can differentiate attributes and elements. This will be the prefix for field names. Default is `@`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `#VALUE`.
+* `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
 
 When writing files the API accepts several options:
 * `path`: Location to write files.

--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -16,6 +16,7 @@
 package com.databricks.spark.xml
 
 import java.io.{InputStream, IOException}
+import java.nio.charset.Charset
 
 import org.apache.commons.io.Charsets
 import org.apache.hadoop.conf.Configuration
@@ -42,6 +43,8 @@ object XmlInputFormat {
   val START_TAG_KEY: String = "xmlinput.start"
   /** configuration key for end tag */
   val END_TAG_KEY: String = "xmlinput.end"
+  /** configuration key for encoding type */
+  val ENCODING_KEY: String = "xmlinput.encoding"
 }
 
 /**
@@ -50,8 +53,10 @@ object XmlInputFormat {
  */
 private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
   private var startTag: Array[Byte] = _
+  private var currentStartTag: Array[Byte] = _
   private var endTag: Array[Byte] = _
-  private var space: Byte = _
+  private var space: Array[Byte] = _
+  private var angleBracket: Array[Byte] = _
 
   private var currentKey: LongWritable = _
   private var currentValue: Text = _
@@ -72,11 +77,15 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       val method = context.getClass.getMethod("getConfiguration")
       method.invoke(context).asInstanceOf[Configuration]
     }
-    startTag = conf.get(XmlInputFormat.START_TAG_KEY).getBytes(Charsets.UTF_8)
-    endTag = conf.get(XmlInputFormat.END_TAG_KEY).getBytes(Charsets.UTF_8)
-    space = ' '
-    require(startTag != null, "The start tag cannot be null.")
-    require(endTag != null, "The end tag cannot be null.")
+    val charset = Charset.forName(conf.get(XmlInputFormat.ENCODING_KEY))
+    startTag = conf.get(XmlInputFormat.START_TAG_KEY).getBytes(charset)
+    endTag = conf.get(XmlInputFormat.END_TAG_KEY).getBytes(charset)
+    space = " ".getBytes(charset)
+    angleBracket = ">".getBytes(charset)
+    require(startTag != null, "Start tag cannot be null.")
+    require(endTag != null, "End tag cannot be null.")
+    require(space != null, "White space cannot be null.")
+    require(angleBracket != null, "Angle bracket cannot be null.")
     start = fileSplit.getStart
     end = start + fileSplit.getLength
 
@@ -143,7 +152,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
   private def next(key: LongWritable, value: Text): Boolean = {
     if (readUntilMatch(startTag, withinBlock = false)) {
       try {
-        buffer.write(startTag)
+        buffer.write(currentStartTag)
         if (readUntilMatch(endTag, withinBlock = true)) {
           key.set(filePosition.getPos)
           value.set(buffer.getData, 0, buffer.getLength)
@@ -169,9 +178,10 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
    */
   private def readUntilMatch(mat: Array[Byte], withinBlock: Boolean): Boolean = {
     var i: Int = 0
-    while (true) {
+    while(true) {
       val b: Int = in.read
       if (b == -1) {
+        currentStartTag = startTag
         return false
       }
       if (withinBlock) {
@@ -180,13 +190,14 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       if (b == mat(i)) {
         i += 1
         if (i >= mat.length) {
+          currentStartTag = startTag
           return true
         }
       }
       else {
-        if (i == (mat.length - 1)) {
-          if (b == space && !withinBlock) {
-            startTag(startTag.length - 1) = space
+        // The start tag might have attributes. In this case, we decide it by the space after tag
+        if (i == (mat.length - angleBracket.length) && !withinBlock) {
+          if (checkAttributes(b)){
             return true
           }
         }
@@ -195,6 +206,20 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       if (!withinBlock && i == 0 && filePosition.getPos > end) {
         return false
       }
+    }
+    false
+  }
+
+  private def checkAttributes(current: Int): Boolean = {
+    var len = 0
+    var b = current
+    while(len < space.length && b == space(len)) {
+      len += 1
+      if (len >= space.length) {
+        currentStartTag = startTag.take(startTag.length - angleBracket.length) ++ space
+        return true
+      }
+      b = in.read
     }
     false
   }
@@ -212,7 +237,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       }
     } finally {
       if (decompressor != null) {
-        CodecPool.returnDecompressor(decompressor);
+        CodecPool.returnDecompressor(decompressor)
         decompressor = null
       }
     }

--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -18,7 +18,6 @@ package com.databricks.spark.xml
 import java.io.{InputStream, IOException}
 import java.nio.charset.Charset
 
-import org.apache.commons.io.Charsets
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Seekable
 import org.apache.hadoop.io.compress._
@@ -69,7 +68,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
 
   private val buffer: DataOutputBuffer = new DataOutputBuffer
 
-  def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {
+  override def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {
     val fileSplit: FileSplit = split.asInstanceOf[FileSplit]
     val conf: Configuration = {
       // Use reflection to get the Configuration. This is necessary because TaskAttemptContext is

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -32,14 +32,13 @@ private[xml] object XmlFile {
                   rowTag: String): RDD[String] = {
     context.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, s"<$rowTag>")
     context.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, s"</$rowTag>")
+    context.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, charset)
     if (Charset.forName(charset) == Charset.forName(XmlOptions.DEFAULT_CHARSET)) {
       context.newAPIHadoopFile(location,
         classOf[XmlInputFormat],
         classOf[LongWritable],
         classOf[Text]).map(pair => new String(pair._2.getBytes, 0, pair._2.getLength))
     } else {
-      // can't pass a Charset object here cause its not serializable
-      // TODO: maybe use mapPartitions instead?
       context.newAPIHadoopFile(location,
         classOf[XmlInputFormat],
         classOf[LongWritable],

--- a/src/test/resources/cars-iso-8859-1.xml
+++ b/src/test/resources/cars-iso-8859-1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <year>2012</year>
+        <make>Tesla</make>
+        <model>S</model>
+        <comment>No comment</comment>
+    </ROW>
+    <ROW>
+        <year>1997</year>
+        <make>Ford</make>
+        <model>E350</model>
+        <comment>Go get one now they are going fast</comment>
+    </ROW>
+    <ROW>
+        <year>2015</year>
+        <make>Chevy</make>
+        <model>Volt</model>
+        <comment>No</comment>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -35,6 +35,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val booksNestedArrayFile = "src/test/resources/books-nested-array.xml"
   val booksComplicatedFile = "src/test/resources/books-complicated.xml"
   val carsFile = "src/test/resources/cars.xml"
+  val carsFile8859 = "src/test/resources/cars-iso-8859-1.xml"
   val carsFileGzip = "src/test/resources/cars.xml.gz"
   val carsFileBzip2 = "src/test/resources/cars.xml.bz2"
   val booksAttributesInNoChild = "src/test/resources/books-attributes-in-no-child.xml"
@@ -73,6 +74,20 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     assert(results.size === numCars)
   }
+
+  test("DSL test for iso-8859-1 encoded file") {
+    val dataFrame = new XmlReader()
+      .withCharset("iso-8859-1")
+      .xmlFile(sqlContext, carsFile8859)
+    assert(dataFrame.select("year").collect().size === numCars)
+
+    val results = dataFrame
+      .select("comment", "year")
+      .where(dataFrame("year") === 2012)
+    assert(results.first.getString(0) === "No comment")
+    assert(results.first.getLong(1) === 2012)
+  }
+
 
   test("DSL test compressed file") {
     val results = sqlContext

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -88,7 +88,6 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.first.getLong(1) === 2012)
   }
 
-
   test("DSL test compressed file") {
     val results = sqlContext
       .xmlFile(carsFileGzip)


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/18
Currently, this library only support UTF-8. This PR lets this library support different encodings.