### PR TITLE
Add a support to select codec as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ When writing files the API accepts several options:
 * `nullValue`: The value to write `null` value. Default is string `null`.
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `@`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `#VALUE`.
+* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`. Defaults to no compression when a codec is not specified.
 
 Currently it supports the shorten name useage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
 
@@ -208,7 +209,6 @@ selectedData.write
     .option("rowTag", "book")
     .save("newbooks.xml")
 ```
-
 
 __Spark 1.3:__
 

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -89,7 +89,8 @@ class DefaultSource
     }
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      data.saveAsXmlFile(path, parameters)
+      val codecClass = compressionCodecClass(XmlOptions.createFromConfigMap(parameters).codec)
+      data.saveAsXmlFile(filesystemPath.toString, parameters, codecClass)
     }
     createRelation(sqlContext, parameters, data.schema)
   }

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -20,6 +20,7 @@ package com.databricks.spark.xml
  */
 private[xml] case class XmlOptions(
   charset: String = XmlOptions.DEFAULT_CHARSET,
+  codec: String = null,
   rowTag: String = XmlOptions.DEFAULT_ROW_TAG,
   rootTag: String = XmlOptions.DEFAULT_ROOT_TAG,
   samplingRatio: Double = 1.0,
@@ -40,9 +41,8 @@ private[xml] object XmlOptions {
   val DEFAULT_NULL_VALUE = "null"
 
   def createFromConfigMap(parameters: Map[String, String]): XmlOptions = XmlOptions(
-    // TODO Support different encoding types.
-    // TODO validate encoidng types. maybe with Charset.forname()
     charset = parameters.getOrElse("charset", DEFAULT_CHARSET),
+    codec = parameters.get("codec").orNull,
     rowTag = parameters.getOrElse("rowTag", DEFAULT_ROW_TAG),
     rootTag = parameters.getOrElse("rootTag", DEFAULT_ROOT_TAG),
     samplingRatio = parameters.get("samplingRatio").map(_.toDouble).getOrElse(1.0),

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -32,6 +32,11 @@ class XmlReader extends Serializable {
     this
   }
 
+  def withCompression(codec: String): XmlReader = {
+    parameters += ("codec" -> codec)
+    this
+  }
+
   def withRowTag(rowTag: String): XmlReader = {
     parameters += ("rowTag" -> rowTag)
     this

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -106,7 +106,8 @@ case class XmlRelation protected[spark] (
               + s" to INSERT OVERWRITE a XML table:\n${e.toString}")
       }
       // Write the data. We assume that schema isn't changed, and we won't update it.
-      data.saveAsXmlFile(filesystemPath.toString)
+      val codecClass = compressionCodecClass(options.codec)
+      data.saveAsXmlFile(filesystemPath.toString, parameters, codecClass)
     } else {
       sys.error("XML tables only support INSERT OVERWRITE for now.")
     }

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -28,6 +28,16 @@ import com.databricks.spark.xml.util.XmlFile
 import com.databricks.spark.xml.parsers.StaxXmlGenerator
 
 package object xml {
+  private[xml] def compressionCodecClass(className: String): Class[_ <: CompressionCodec] = {
+    className match {
+      case null => null
+      case codec =>
+        // scalastyle:off classforname
+        Class.forName(codec).asInstanceOf[Class[CompressionCodec]]
+        // scalastyle:on classforname
+    }
+  }
+
   /**
    * Adds a method, `xmlFile`, to [[SQLContext]] that allows reading XML data.
    */
@@ -62,6 +72,8 @@ package object xml {
 
   /**
    * Adds a method, `saveAsXmlFile`, to [[DataFrame]] that allows writing XML data.
+   * If compressionCodec is not null the resulting output will be compressed.
+   * Note that a codec entry in the parameters map will be ignored.
    */
   implicit class XmlSchemaRDD(dataFrame: DataFrame) {
     // Note that writing a XML file from [[DataFrame]] having a field [[ArrayType]] with


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/24
This PR added the support to select compression codec for all the APIs.