### PR TITLE
Remove unreachable catches in type inference

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -161,7 +161,7 @@ private[xml] object StaxXmlParser {
       case ByteType => castTo(value, ByteType)
       case ShortType => castTo(value, ShortType)
       case IntegerType => signSafeToInt(value)
-      case _: DecimalType => castTo(value, new DecimalType())
+      case _: DecimalType => castTo(value, new DecimalType(None))
       case NullType => null
       case dataType =>
         sys.error(s"Failed to parse a value for data type $dataType.")

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -161,7 +161,7 @@ private[xml] object StaxXmlParser {
       case ByteType => castTo(value, ByteType)
       case ShortType => castTo(value, ShortType)
       case IntegerType => signSafeToInt(value)
-      case _: DecimalType => castTo(value, new DecimalType(None))
+      case _: DecimalType => castTo(value, new DecimalType())
       case NullType => null
       case dataType =>
         sys.error(s"Failed to parse a value for data type $dataType.")

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -94,14 +94,6 @@ private[xml] object InferSchema {
           }
           Some(inferObject(parser, options, rootAttributes))
         } catch {
-          case _: java.lang.NumberFormatException if !failFast =>
-            logger.warn("Number format exception. " +
-              s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
-            None
-          case _: java.text.ParseException | _: IllegalArgumentException if !failFast =>
-            logger.warn("Parse exception. " +
-              s"Dropping malformed line: ${xml.replaceAll("\n", "")}")
-            None
           case _: XMLStreamException if !failFast =>
             logger.warn(s"Dropping malformed row: ${xml.replaceAll("\n", "")}")
             None


### PR DESCRIPTION
This PR removes the unreachable catches since `NumberFormatException`, `ParseException` and `IllegalArgumentException` are raised when parsing invalid data into some types.
