### PR TITLE
Fix a typo for version at example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ version: 0.2.0
 This package can be added to  Spark using the `--jars` command line option.  For example, to include it when starting the spark shell:
 
 ```
-$ bin/spark-shell --packages com.databricks:spark-xml_2.11:0.2.0
+$ bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.0
 ```
 
 ## Features


### PR DESCRIPTION
As the version is up, the version of example also should be updated.