### PR TITLE
Infer types correctly even if some elements has no attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ version: 0.2.0
 This package can be added to  Spark using the `--jars` command line option.  For example, to include it when starting the spark shell:
 
 ```
-$ bin/spark-shell --packages com.databricks:spark-xml_2.11:0.2.0
+$ bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.0
 ```
 
 ## Features

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -305,6 +305,15 @@ private[xml] object InferSchema {
         case (ty1, ArrayType(ty2, _)) =>
           ArrayType(compatibleType(ty1, ty2))
 
+        // As this library can infer an element with attributes as StructType whereas
+        // some can be inferred as other non-structural data types, this case should be
+        // treated.
+        case (StructType(fields), dt: DataType) =>
+          StructType(fields)
+
+        case (dt: DataType, StructType(fields)) =>
+          StructType(fields)
+
         // strings and every string is a XML object.
         case (_, _) => StringType
       }

--- a/src/test/resources/books-attributes-in-no-child.xml
+++ b/src/test/resources/books-attributes-in-no-child.xml
@@ -3,7 +3,7 @@
    <book id="bk101">
       <author>Gambardella, Matthew</author>
       <title>XML Developer's Guide</title>
-      <price unit="$">44.95</price>
+      <price>44.95</price>
       <publish_date>2000-10-01</publish_date>
    </book>
    <book id="bk102">


### PR DESCRIPTION
If some elements have no child but attributes and other do not, this ignores the attributes.
This PR fixes this by inferring types correctly.

- XML
```xml
   <book>
      <author>Gambardella, Matthew</author>
   </book>
   <book>
      <author id="bk102">Ralls, Kim</author>
   </book>
```

- Dataframe
```
root
 |-- author: string (nullable = true)
```