### PR TITLE
Add descriptions for hadoop inputformat and fix some typoes

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line
 
 ### Hadoop InputFormat
 
-The library contains a Hadoop input format for XML files reading by a start tag and an end tag. This is similar with [XmlInputFormat](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
+The library contains a Hadoop input format for reading XML files by a start tag and an end tag. This is similar with [XmlInputFormat](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
 which you may make direct use of as follows:
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line
 
 ### Hadoop InputFormat
 
-The library contains a Hadoop input format for reading XML files by a start tag and an end tag. This is similar with [XmlInputFormat](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
+The library contains a Hadoop input format for reading XML files by a start tag and an end tag. This is similar with [XmlInputFormat.java](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
 which you may make direct use of as follows:
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ OPTIONS (path "books.xml", rowTag "book")
 
 You can also specify column names and types in DDL. In this case, we do not infer schema.
 ```sql
-CREATE TABLE books (author string, description string, genre string, id string, price double, publish_date string, title string)
+CREATE TABLE books (author string, description string, genre string, @id string, price double, publish_date string, title string)
 USING com.databricks.spark.xml
 OPTIONS (path "books.xml", rowTag "book")
 ```
@@ -459,6 +459,25 @@ write.df(df, "newbooks.csv", "com.databricks.spark.xml", "overwrite")
 ## Building From Source
 This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.10 and 2.11.
 
+
+### Hadoop InputFormat
+
+The library contains a Hadoop input format for XML files reading by a start tag and an end tag. This is similar with [XmlInputFormat](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
+which you may make direct use of as follows:
+
+```scala
+import com.databricks.spark.xml.XmlInputFormat
+
+sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<books>") // This also detects the tags including attributes
+sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</books>")
+sc.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, "utf-8")
+
+val records = context.newAPIHadoopFile(
+  path,
+  classOf[XmlInputFormat],
+  classOf[LongWritable],
+  classOf[Text]).
+```
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,8 @@ which you may make direct use of as follows:
 ```scala
 import com.databricks.spark.xml.XmlInputFormat
 
-sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<books>") // This also detects the tags including attributes
+// This also detects the tags including attributes
+sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<books>")
 sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</books>")
 sc.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, "utf-8")
 
@@ -476,7 +477,7 @@ val records = context.newAPIHadoopFile(
   path,
   classOf[XmlInputFormat],
   classOf[LongWritable],
-  classOf[Text]).
+  classOf[Text])
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ which you may make direct use of as follows:
 ```scala
 import com.databricks.spark.xml.XmlInputFormat
 
-// This also detects the tags including attributes
+// This will detect the tags including attributes
 sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<books>")
 sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</books>")
 sc.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, "utf-8")

--- a/README.md
+++ b/README.md
@@ -456,10 +456,6 @@ df <- read.df(sqlContext, "books.xml", source = "com.databricks.spark.xml", rowT
 write.df(df, "newbooks.csv", "com.databricks.spark.xml", "overwrite")
 ```
 
-## Building From Source
-This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.10 and 2.11.
-
-
 ## Hadoop InputFormat
 
 The library contains a Hadoop input format for reading XML files by a start tag and an end tag. This is similar with [XmlInputFormat.java](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
@@ -479,6 +475,9 @@ val records = context.newAPIHadoopFile(
   classOf[LongWritable],
   classOf[Text])
 ```
+
+## Building From Source
+This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.10 and 2.11.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ write.df(df, "newbooks.csv", "com.databricks.spark.xml", "overwrite")
 This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.10 and 2.11.
 
 
-### Hadoop InputFormat
+## Hadoop InputFormat
 
 The library contains a Hadoop input format for reading XML files by a start tag and an end tag. This is similar with [XmlInputFormat.java](https://github.com/apache/mahout/blob/9d14053c80a1244bdf7157ab02748a492ae9868a/integration/src/main/java/org/apache/mahout/text/wikipedia/XmlInputFormat.java) in [Mahout](http://mahout.apache.org) but supports to read compressed files, different encodings and read elements including attributes,
 which you may make direct use of as follows:

--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -76,7 +76,8 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       val method = context.getClass.getMethod("getConfiguration")
       method.invoke(context).asInstanceOf[Configuration]
     }
-    val charset = Charset.forName(conf.get(XmlInputFormat.ENCODING_KEY))
+    val charset =
+      Charset.forName(conf.get(XmlInputFormat.ENCODING_KEY, XmlOptions.DEFAULT_CHARSET))
     startTag = conf.get(XmlInputFormat.START_TAG_KEY).getBytes(charset)
     endTag = conf.get(XmlInputFormat.END_TAG_KEY).getBytes(charset)
     space = " ".getBytes(charset)


### PR DESCRIPTION
Similarly with [spark-redshift](https://github.com/databricks/spark-redshift), this library has a custom inputformat for XML files. So, this PR adds some descriptions for using them.

Also, this corrects some typoes in `README.md` .