### PR TITLE
Fix to read attributes only in some elements and not to write attributes and elements for null

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When writing files the API accepts several options:
 * `path`: Location to write files.
 * `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
 * `rootTag`: The root tag of your xml files to treat as the root. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `books`. Default is `ROWS`.
-* `nullValue`: The value to write `null` value. Default is string `null`.
+* `nullValue`: The value to write `null` value. Default is string `null`. When this is `null`, it does not write attributes and elements for fields.
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `@`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `#VALUE`.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`. Defaults to no compression when a codec is not specified.

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -38,7 +38,7 @@ private[xml] object XmlOptions {
   val DEFAULT_ROW_TAG = "ROW"
   val DEFAULT_ROOT_TAG = "ROWS"
   val DEFAULT_CHARSET = "UTF-8"
-  val DEFAULT_NULL_VALUE = "null"
+  val DEFAULT_NULL_VALUE = null
 
   def createFromConfigMap(parameters: Map[String, String]): XmlOptions = XmlOptions(
     charset = parameters.getOrElse("charset", DEFAULT_CHARSET),

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -37,13 +37,17 @@ private[xml] object StaxXmlGenerator {
             writer: IndentingXMLStreamWriter,
             options: XmlOptions)(row: Row): Unit = {
     def writeChildElement: (String, DataType, Any) => Unit = {
-        case (_, _, null) |(_, NullType, _) if options.nullValue == null =>
-        // Because usually elements having `null` do not exist, just do not write
-        // elements when given values are `null`.
-        case (name, dt, v) =>
-          writer.writeStartElement(name)
-          writeElement(dt, v)
-          writer.writeEndElement()
+      // If this is meant to be value but in no child, write only a value
+      case (_, _, null) |(_, NullType, _) if options.nullValue == null =>
+      // Because usually elements having `null` do not exist, just do not write
+      // elements when given values are `null`.
+      case (name, dt, v) if name == options.valueTag =>
+        // If this is meant to be value but in no child, write only a value
+        writeElement(dt, v)
+      case (name, dt, v) =>
+        writer.writeStartElement(name)
+        writeElement(dt, v)
+        writer.writeEndElement()
     }
 
     def writeChild(name: String, dt: DataType, v: Any): Unit = {
@@ -55,13 +59,9 @@ private[xml] object StaxXmlGenerator {
           }
         case _ if name.startsWith(options.attributePrefix) =>
           writer.writeAttribute(name.substring(options.attributePrefix.length), v.toString)
-        // If this is meant to be value but in no child, write only a value
-        case _ if name == options.valueTag =>
-          writeElement(dt, v)
         // For ArrayType, we just need to write each as XML element.
         case (ArrayType(ty, _), v: Seq[_]) =>
           v.foreach(e => writeChildElement(name, ty, e))
-
         // For other datatypes, we just write normal elements.
         case _ =>
           writeChildElement(name, dt, v)

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -36,7 +36,7 @@ private[xml] object StaxXmlGenerator {
   def apply(schema: StructType,
             writer: IndentingXMLStreamWriter,
             options: XmlOptions)(row: Row): Unit = {
-    def writeChildElement:(String, DataType, Any) => Unit = {
+    def writeChildElement: (String, DataType, Any) => Unit = {
         case (_, _, null) |(_, NullType, _) if options.nullValue == null =>
         // Because usually elements having `null` do not exist, just do not write
         // elements when given values are `null`.

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -149,23 +149,21 @@ private[xml] object StaxXmlParser {
     }
   }
 
-  private def convertStringTo(value: String, dataType: DataType): Any = {
-    dataType match {
-      case LongType => signSafeToLong(value)
-      case DoubleType => signSafeToDouble(value)
-      case BooleanType => castTo(value, BooleanType)
-      case StringType => castTo(value, StringType)
-      case DateType => castTo(value, DateType)
-      case TimestampType => castTo(value, TimestampType)
-      case FloatType => signSafeToFloat(value)
-      case ByteType => castTo(value, ByteType)
-      case ShortType => castTo(value, ShortType)
-      case IntegerType => signSafeToInt(value)
-      case _: DecimalType => castTo(value, new DecimalType(None))
-      case NullType => null
-      case dataType =>
-        sys.error(s"Failed to parse a value for data type $dataType.")
-    }
+  private def convertStringTo: (String, DataType) => Any = {
+    case (null, _) | (_, NullType) => null
+    case (v, LongType) => signSafeToLong(v)
+    case (v, DoubleType) => signSafeToDouble(v)
+    case (v, BooleanType) => castTo(v, BooleanType)
+    case (v, StringType) => castTo(v, StringType)
+    case (v, DateType) => castTo(v, DateType)
+    case (v, TimestampType) => castTo(v, TimestampType)
+    case (v, FloatType) => signSafeToFloat(v)
+    case (v, ByteType) => castTo(v, ByteType)
+    case (v, ShortType) => castTo(v, ShortType)
+    case (v, IntegerType) => signSafeToInt(v)
+    case (v, _: DecimalType) => castTo(v, new DecimalType(None))
+    case (_, dataType) =>
+      sys.error(s"Failed to parse a value for data type $dataType.")
   }
 
   /**
@@ -222,7 +220,14 @@ private[xml] object StaxXmlParser {
       } else {
         val attrFields = attributes.map(options.attributePrefix + _.getName.getLocalPart)
         val attrValues = attributes.map(_.getValue)
-        attrFields.zip(attrValues).toMap
+        val nullSafeValues = {
+          if (options.treatEmptyValuesAsNulls) {
+            attrValues.map (v => if (v.trim.isEmpty) null else v)
+          } else {
+            attrValues
+          }
+        }
+        attrFields.zip(nullSafeValues).toMap
       }
     }
 
@@ -266,24 +271,22 @@ private[xml] object StaxXmlParser {
                       nameToIndex.get(f).foreach(row.update(_, v))
                   }
                   row(index) = convertField(parser, dataType, options)
-                case ArrayType(st: StructType, _) if attributes.nonEmpty =>
-                  // If the given type is array but the element type is StructType,
-                  // we should push and write current attributes as fields in elements
-                  // in this array.
+                case ArrayType(dt: DataType, _) =>
                   val elements = {
                     val values = Option(row(index))
                       .map(_.asInstanceOf[ArrayBuffer[Any]])
                       .getOrElse(ArrayBuffer.empty[Any])
-                    val newValue = convertObject(parser, st, options, attributes)
-                    values :+ newValue
-                  }
-                  row(index) = elements
-                case _: ArrayType =>
-                  val elements = {
-                    val values = Option(row(index))
-                      .map(_.asInstanceOf[ArrayBuffer[Any]])
-                      .getOrElse(ArrayBuffer.empty[Any])
-                    val newValue = convertField(parser, dataType, options)
+                    val newValue = {
+                      dt match {
+                        case st: StructType  if attributes.nonEmpty =>
+                          // If the given type is array but the element type is StructType,
+                          // we should push and write current attributes as fields in elements
+                          // in this array.
+                          convertObject(parser, st, options, attributes)
+                        case _ =>
+                          convertField(parser, dataType, options)
+                      }
+                    }
                     values :+ newValue
                   }
                   row(index) = elements

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -161,8 +161,15 @@ private[xml] object InferSchema {
         Map.empty[String, String]
       } else {
         val attrFields = attributes.map(options.attributePrefix + _.getName.getLocalPart)
-        val attrDataTypes = attributes.map(_.getValue)
-        attrFields.zip(attrDataTypes).toMap
+        val attrValues = attributes.map(_.getValue)
+        val nullSafeValues = {
+          if (options.treatEmptyValuesAsNulls) {
+            attrValues.map (v => if (v.trim.isEmpty) null else v)
+          } else {
+            attrValues
+          }
+        }
+        attrFields.zip(nullSafeValues).toMap
       }
     }
 

--- a/src/test/resources/books-complicated.xml
+++ b/src/test/resources/books-complicated.xml
@@ -44,7 +44,6 @@
          <genreid>2</genreid>
          <name>Fantasy</name>
       </genre>
-      <price>5.95</price>
       <publish_dates>
          <publish_date>
             <year>2000</year>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -300,6 +300,23 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(booksCopy.collect.map(_.toString).toSet === books.collect.map(_.toString).toSet)
   }
 
+  test("DSL save with nullValue and treatEmptyValuesAsNulls") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "books-copy.xml"
+
+    val books = sqlContext.xmlFile(booksComplicatedFile, rowTag = booksTag)
+    books.saveAsXmlFile(copyFilePath,
+      Map("rootTag" -> booksRootTag, "rowTag" -> booksTag, "nullValue" -> ""))
+
+    val booksCopy =
+      sqlContext.xmlFile(copyFilePath, rowTag = booksTag, treatEmptyValuesAsNulls = true)
+
+    assert(booksCopy.count == books.count)
+    assert(booksCopy.collect.map(_.toString).toSet === books.collect.map(_.toString).toSet)
+  }
+
   test("DSL save dataframe not read from a XML file") {
     // Create temp directory
     TestUtils.deleteRecursively(new File(tempEmptyDir))


### PR DESCRIPTION
This PR fixes the bug while reading attributes. If there are attributes only in some elements in an array, it fails to read attributes. 

Also, this PR fixes this to write nothing for `null`. 