### PR TITLE
Fix Python example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ from pyspark.sql import SQLContext
 sqlContext = SQLContext(sc)
 
 df = sqlContext.read.format('com.databricks.spark.xml').options(rowTag='book').load('books.xml')
-df.select("author", "@id").collect()
+df.select("author", "@id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
 ```
 
 You can manually specify schema:

--- a/README.md
+++ b/README.md
@@ -364,7 +364,10 @@ from pyspark.sql import SQLContext
 sqlContext = SQLContext(sc)
 
 df = sqlContext.read.format('com.databricks.spark.xml').options(rowTag='book').load('books.xml')
-df.select("author", "@id").write.format('com.databricks.spark.xml').options(rowTag='book', rootTag='books').save('newbooks.xml')
+df.select("author", "@id").write \
+    .format('com.databricks.spark.xml') \
+    .options(rowTag='book', rootTag='books') \
+    .save('newbooks.xml')
 ```
 
 You can manually specify schema:

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ from pyspark.sql import SQLContext
 sqlContext = SQLContext(sc)
 
 df = sqlContext.read.format('com.databricks.spark.xml').options(rowTag='book').load('books.xml')
-df.select("author", "@id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
+df.select("author", "@id").write.format('com.databricks.spark.xml').options(rowTag='book', rootTag='books').save('newbooks.xml')
 ```
 
 You can manually specify schema:


### PR DESCRIPTION
This PR fixes the Python example for including write just like the other examples.