### PR TITLE
Refactor options (not case class and same format with CSV and JSON options).

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -20,7 +20,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-import com.databricks.spark.xml.util.{TypeCast, XmlFile}
+import com.databricks.spark.xml.util.XmlFile
 
 /**
  * Provides access to XML data from pure SQL statements (i.e. for users of the
@@ -54,7 +54,7 @@ class DefaultSource
     val path = checkPath(parameters)
     // We need the `charset` and `rowTag` before creating the relation.
     val (charset, rowTag) = {
-      val options = XmlOptions.createFromConfigMap(parameters)
+      val options = XmlOptions(parameters)
       (options.charset, options.rowTag)
     }
 
@@ -89,7 +89,7 @@ class DefaultSource
     }
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      val codecClass = compressionCodecClass(XmlOptions.createFromConfigMap(parameters).codec)
+      val codecClass = compressionCodecClass(XmlOptions(parameters).codec)
       data.saveAsXmlFile(filesystemPath.toString, parameters, codecClass)
     }
     createRelation(sqlContext, parameters, data.schema)

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -19,7 +19,7 @@ package com.databricks.spark.xml
  * Options for the XML data source.
  */
 private[xml] class XmlOptions(
-    @transient parameters: Map[String, String])
+    @transient private val parameters: Map[String, String])
   extends Serializable{
 
   val charset = parameters.getOrElse("charset", XmlOptions.DEFAULT_CHARSET)

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -18,19 +18,24 @@ package com.databricks.spark.xml
 /**
  * Options for the XML data source.
  */
-private[xml] case class XmlOptions(
-  charset: String = XmlOptions.DEFAULT_CHARSET,
-  codec: String = null,
-  rowTag: String = XmlOptions.DEFAULT_ROW_TAG,
-  rootTag: String = XmlOptions.DEFAULT_ROOT_TAG,
-  samplingRatio: Double = 1.0,
-  excludeAttributeFlag: Boolean = false,
-  treatEmptyValuesAsNulls: Boolean = false,
-  failFastFlag: Boolean = false,
-  attributePrefix: String = XmlOptions.DEFAULT_ATTRIBUTE_PREFIX,
-  valueTag: String = XmlOptions.DEFAULT_VALUE_TAG,
-  nullValue: String = XmlOptions.DEFAULT_NULL_VALUE
-)
+private[xml] class XmlOptions(
+    @transient parameters: Map[String, String])
+  extends Serializable{
+
+  val charset = parameters.getOrElse("charset", XmlOptions.DEFAULT_CHARSET)
+  val codec = parameters.get("codec").orNull
+  val rowTag = parameters.getOrElse("rowTag", XmlOptions.DEFAULT_ROW_TAG)
+  val rootTag = parameters.getOrElse("rootTag", XmlOptions.DEFAULT_ROOT_TAG)
+  val samplingRatio = parameters.get("samplingRatio").map(_.toDouble).getOrElse(1.0)
+  val excludeAttributeFlag = parameters.get("excludeAttribute").map(_.toBoolean).getOrElse(false)
+  val treatEmptyValuesAsNulls =
+    parameters.get("treatEmptyValuesAsNulls").map(_.toBoolean).getOrElse(false)
+  val failFastFlag = parameters.get("failFast").map(_.toBoolean).getOrElse(false)
+  val attributePrefix =
+    parameters.getOrElse("attributePrefix", XmlOptions.DEFAULT_ATTRIBUTE_PREFIX)
+  val valueTag = parameters.getOrElse("valueTag", XmlOptions.DEFAULT_VALUE_TAG)
+  val nullValue = parameters.getOrElse("nullValue", XmlOptions.DEFAULT_NULL_VALUE)
+}
 
 private[xml] object XmlOptions {
   val DEFAULT_ATTRIBUTE_PREFIX = "@"
@@ -40,18 +45,5 @@ private[xml] object XmlOptions {
   val DEFAULT_CHARSET = "UTF-8"
   val DEFAULT_NULL_VALUE = null
 
-  def createFromConfigMap(parameters: Map[String, String]): XmlOptions = XmlOptions(
-    charset = parameters.getOrElse("charset", DEFAULT_CHARSET),
-    codec = parameters.get("codec").orNull,
-    rowTag = parameters.getOrElse("rowTag", DEFAULT_ROW_TAG),
-    rootTag = parameters.getOrElse("rootTag", DEFAULT_ROOT_TAG),
-    samplingRatio = parameters.get("samplingRatio").map(_.toDouble).getOrElse(1.0),
-    excludeAttributeFlag = parameters.get("excludeAttribute").map(_.toBoolean).getOrElse(false),
-    treatEmptyValuesAsNulls =
-      parameters.get("treatEmptyValuesAsNulls").map(_.toBoolean).getOrElse(false),
-    failFastFlag = parameters.get("failFast").map(_.toBoolean).getOrElse(false),
-    attributePrefix = parameters.getOrElse("attributePrefix", DEFAULT_ATTRIBUTE_PREFIX),
-    valueTag = parameters.getOrElse("valueTag", DEFAULT_VALUE_TAG),
-    nullValue = parameters.getOrElse("nullValue", DEFAULT_NULL_VALUE)
-  )
+  def apply(parameters: Map[String, String]): XmlOptions = new XmlOptions(parameters)
 }

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -82,7 +82,7 @@ class XmlReader extends Serializable {
   def xmlFile(sqlContext: SQLContext, path: String): DataFrame = {
     // We need the `charset` and `rowTag` before creating the relation.
     val (charset, rowTag) = {
-      val options = XmlOptions.createFromConfigMap(parameters.toMap)
+      val options = XmlOptions(parameters.toMap)
       (options.charset, options.rowTag)
     }
     val relation: XmlRelation = XmlRelation(

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -39,7 +39,7 @@ case class XmlRelation protected[spark] (
 
   private val logger = LoggerFactory.getLogger(XmlRelation.getClass)
 
-  private val options = XmlOptions.createFromConfigMap(parameters)
+  private val options = XmlOptions(parameters)
 
   override val schema: StructType = {
     Option(userSchema).getOrElse {

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -94,7 +94,7 @@ package object xml {
     // Namely, roundtrip in writing and reading can end up in different schema structure.
     def saveAsXmlFile(path: String, parameters: Map[String, String] = Map(),
                       compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
-      val options = XmlOptions.createFromConfigMap(parameters.toMap)
+      val options = XmlOptions(parameters.toMap)
       val startElement = s"<${options.rootTag}>"
       val endElement = s"</${options.rootTag}>"
       val rowSchema = dataFrame.schema


### PR DESCRIPTION
This PR simply fixes `XmlOptions` to have a similar form with `JSONOptions` or `CSVOptions` in Spark.

1. `XmlOptions`, not a case class
2. `createFromConfigMap()` to `apply()` (according to [databricks/scala-style-guide#apply-method](https://github.com/databricks/scala-style-guide#apply-method)).