### PR TITLE
Support for reading multiple character events in an XML element

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.xml.parsers
 import java.io.ByteArrayInputStream
 import javax.xml.stream.events.{Attribute, XMLEvent}
 import javax.xml.stream.events._
-import javax.xml.stream.{XMLStreamException, XMLEventReader, XMLInputFactory}
+import javax.xml.stream.{XMLStreamException, XMLStreamConstants, XMLEventReader, XMLInputFactory}
 
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable.ArrayBuffer
@@ -51,7 +51,7 @@ private[xml] object StaxXmlParser {
         val parser = factory.createXMLEventReader(reader)
         try {
           val rootAttributes = {
-            val rootEvent = skipUntil(parser, classOf[StartElement])
+            val rootEvent = StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
             rootEvent.asStartElement.getAttributes
               .map(_.asInstanceOf[Attribute]).toArray
           }
@@ -73,31 +73,6 @@ private[xml] object StaxXmlParser {
         }
       }
     }
-  }
-
-  /**
-   * Skips elements until this meets the given type of a element
-   */
-  def skipUntil(parser: XMLEventReader, eventType: Class[_ <: XMLEvent]): XMLEvent = {
-    var event = parser.nextEvent
-    while(parser.hasNext && event.getClass != eventType) {
-      event = parser.nextEvent
-    }
-    event
-  }
-
-  /**
-   * Read data for all continuous character events.
-   */
-  def readDataFully(parser: XMLEventReader): String = {
-    var event = parser.peek
-    var data: String = if (event.isCharacters) "" else null
-    while(event.isCharacters) {
-      data += event.asCharacters.getData
-      parser.nextEvent
-      event = parser.peek
-    }
-    data
   }
 
   /**
@@ -154,12 +129,13 @@ private[xml] object StaxXmlParser {
         (next, dataType) match {
           case (_: EndElement, _) => if (options.treatEmptyValuesAsNulls) null else data
           case (_: StartElement, dt: DataType) => convertComplicatedType(dt)
-          case (_: Characters, dt: DataType) => convertStringTo(readDataFully(parser), dt)
+          case (_: Characters, dt: DataType) =>
+            convertStringTo(StaxXmlParserUtils.readDataFully(parser), dt)
         }
       case (c: Characters, ArrayType(st, _)) if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
-        convertStringTo(readDataFully(parser), st)
+        convertStringTo(StaxXmlParserUtils.readDataFully(parser), st)
       case (c: Characters, dt: DataType) if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
-        convertStringTo(readDataFully(parser), dt)
+        convertStringTo(StaxXmlParserUtils.readDataFully(parser), dt)
       case (e: XMLEvent, dt: DataType) =>
         sys.error(s"Failed to parse a value for data type $dt with event ${e.toString}")
     }
@@ -317,3 +293,4 @@ private[xml] object StaxXmlParser {
     Row.fromSeq(row)
   }
 }
+

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -76,32 +76,6 @@ private[xml] object StaxXmlParser {
   }
 
   /**
-   * Check if current event points the EndElement.
-   */
-  def checkEndElement(parser: XMLEventReader, options: XmlOptions): Boolean = {
-    val current = parser.peek
-    current match {
-      case _: EndElement => true
-      case _: StartElement => false
-      case _: Characters =>
-        // When `Characters` is found here, we need to look further to decide
-        // if this is really `EndElement` because this can be whitespace between
-        // `EndElement` and `StartElement`.
-        val next = {
-          parser.nextEvent
-          parser.peek
-        }
-        next match {
-          case _: EndElement => true
-          case _: StartElement => false
-          case _: Characters => checkEndElement(parser, options)
-          case e: XMLEvent =>
-            sys.error(s"Failed to parse data with unexpected event ${e.toString}")
-        }
-    }
-  }
-
-  /**
    * Parse the current token (and related children) according to a desired schema
    */
   private[xml] def convertField(parser: XMLEventReader,
@@ -173,7 +147,7 @@ private[xml] object StaxXmlParser {
           keys += e.getName.getLocalPart
           values += convertField(parser, valueType, options)
         case _: EndElement =>
-          shouldStop = checkEndElement(parser, options)
+          shouldStop = StaxXmlParserUtils.checkEndElement(parser, options)
         case _ =>
           shouldStop = shouldStop && parser.hasNext
       }
@@ -285,7 +259,7 @@ private[xml] object StaxXmlParser {
               }
           }
         case _: EndElement =>
-          shouldStop = checkEndElement(parser, options)
+          shouldStop = StaxXmlParserUtils.checkEndElement(parser, options)
         case _ =>
           shouldStop = shouldStop && parser.hasNext
       }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -79,9 +79,9 @@ private[xml] object StaxXmlParser {
    * Skips elements until this meets the given type of a element
    */
   def skipUntil(parser: XMLEventReader, eventType: Int): XMLEvent = {
-    var event = parser.nextEvent()
+    var event = parser.nextEvent
     while(parser.hasNext && event.getEventType != eventType) {
-      event = parser.nextEvent()
+      event = parser.nextEvent
     }
     event
   }
@@ -90,17 +90,14 @@ private[xml] object StaxXmlParser {
    * Read data for all continuous character events.
    */
   def readData(parser: XMLEventReader): String = {
-    var data: String = null
-    while(true) {
-      parser.peek match {
-        case c: Characters =>
-          if (data == null) data = c.getData else data += c.getData
-        case _ =>
-          return data
-      }
+    var event = parser.peek
+    var data: String = if (event.isCharacters) "" else null
+    while(event.isCharacters) {
+      data += event.asCharacters.getData
       parser.nextEvent
+      event = parser.peek
     }
-    null
+    data
   }
 
   /**
@@ -122,9 +119,7 @@ private[xml] object StaxXmlParser {
         next match {
           case _: EndElement => true
           case _: StartElement => false
-          case _: Characters =>
-            readData(parser)
-            false
+          case _: Characters => checkEndElement(parser, options)
           case e: XMLEvent =>
             sys.error(s"Failed to parse data with unexpected event ${e.toString}")
         }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -266,6 +266,7 @@ private[xml] object StaxXmlParser {
           val attributes = e.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           // Set elements and other attributes to the row
           val field = e.asStartElement.getName.getLocalPart
+          // TODO: Simplify the complex logic below.
           nameToIndex.get(field).foreach {
             case index =>
               val dataType = schema(index).dataType

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -16,7 +16,7 @@ private[xml] object StaxXmlParserUtils {
   }
 
   /**
-   * Read data for all continuous character events.
+   * Read the data for all continuous character events within an element.
    */
   def readDataFully(parser: XMLEventReader): String = {
     var event = parser.peek

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -1,0 +1,31 @@
+package com.databricks.spark.xml.parsers
+
+import javax.xml.stream.XMLEventReader
+import javax.xml.stream.events.XMLEvent
+
+private[xml] object StaxXmlParserUtils {
+  /**
+   * Skips elements until this meets the given type of a element
+   */
+  def skipUntil(parser: XMLEventReader, eventType: Int): XMLEvent = {
+    var event = parser.nextEvent
+    while(parser.hasNext && event.getEventType != eventType) {
+      event = parser.nextEvent
+    }
+    event
+  }
+
+  /**
+   * Read data for all continuous character events.
+   */
+  def readDataFully(parser: XMLEventReader): String = {
+    var event = parser.peek
+    var data: String = if (event.isCharacters) "" else null
+    while(event.isCharacters) {
+      data += event.asCharacters.getData
+      parser.nextEvent
+      event = parser.peek
+    }
+    data
+  }
+}

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -1,7 +1,9 @@
 package com.databricks.spark.xml.parsers
 
 import javax.xml.stream.XMLEventReader
-import javax.xml.stream.events.XMLEvent
+import javax.xml.stream.events.{Characters, StartElement, EndElement, XMLEvent}
+
+import com.databricks.spark.xml.XmlOptions
 
 private[xml] object StaxXmlParserUtils {
   /**
@@ -28,4 +30,28 @@ private[xml] object StaxXmlParserUtils {
     }
     data
   }
+
+  /**
+   * Check if current event points the EndElement.
+   */
+  def checkEndElement(parser: XMLEventReader, options: XmlOptions): Boolean = {
+    val current = parser.peek
+    current match {
+      case _: EndElement => true
+      case _: StartElement => false
+      case _: Characters =>
+        // When `Characters` is found here, we need to look further to decide
+        // if this is really `EndElement` because this can be whitespace between
+        // `EndElement` and `StartElement`.
+        val next = {
+          parser.nextEvent
+          parser.peek
+        }
+        next match {
+          case _: EndElement => true
+          case _: XMLEvent => false
+        }
+    }
+  }
+
 }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -17,8 +17,9 @@ package com.databricks.spark.xml.util
 
 import java.io.ByteArrayInputStream
 import javax.xml.stream.events._
-import javax.xml.stream.{XMLStreamException, XMLEventReader, XMLInputFactory}
+import javax.xml.stream.{XMLStreamConstants, XMLStreamException, XMLEventReader, XMLInputFactory}
 
+import com.databricks.spark.xml.parsers.StaxXmlParserUtils
 import org.slf4j.LoggerFactory
 
 import scala.collection.Seq
@@ -88,7 +89,7 @@ private[xml] object InferSchema {
         val parser = factory.createXMLEventReader(reader)
         try {
           val rootAttributes = {
-            val rootEvent = skipUntil(parser, classOf[StartElement])
+            val rootEvent = StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
             rootEvent.asStartElement.getAttributes
               .map(_.asInstanceOf[Attribute]).toArray
           }
@@ -140,11 +141,11 @@ private[xml] object InferSchema {
           case _: EndElement if options.treatEmptyValuesAsNulls => NullType
           case _: EndElement => StringType
           case _: StartElement => inferObject(parser, options)
-          case _: Characters => inferTypeFromString(readDataFully(parser))
+          case _: Characters => inferTypeFromString(StaxXmlParserUtils.readDataFully(parser))
         }
       case c: Characters if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
         // This means data exists
-        inferTypeFromString(readDataFully(parser))
+        inferTypeFromString(StaxXmlParserUtils.readDataFully(parser))
 
       case e: XMLEvent =>
         sys.error(s"Failed to parse data with unexpected event ${e.toString}")

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -140,10 +140,11 @@ private[xml] object InferSchema {
           case _: EndElement if options.treatEmptyValuesAsNulls => NullType
           case _: EndElement => StringType
           case _: StartElement => inferObject(parser, options)
+          case _: Characters => inferTypeFromString(readData(parser))
         }
       case c: Characters if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
         // This means data exists
-        inferTypeFromString(c.asCharacters().getData)
+        inferTypeFromString(readData(parser))
 
       case e: XMLEvent =>
         sys.error(s"Failed to parse data with unexpected event ${e.toString}")

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -177,6 +177,7 @@ private[xml] object InferSchema {
     val builder = Seq.newBuilder[StructField]
     val nameToDataTypes = collection.mutable.Map.empty[String, ArrayBuffer[DataType]]
     var shouldStop = false
+    // TODO: Simplify the complex logic below.
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -29,7 +29,6 @@ import scala.collection.JavaConversions._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.util.TypeCast._
-import com.databricks.spark.xml.parsers.StaxXmlParser._
 import com.databricks.spark.xml.XmlOptions
 
 private[xml] object InferSchema {
@@ -218,7 +217,7 @@ private[xml] object InferSchema {
           dataTypes += inferredType
           nameToDataTypes += (field -> dataTypes)
         case _: EndElement =>
-          shouldStop = checkEndElement(parser, options)
+          shouldStop = StaxXmlParserUtils.checkEndElement(parser, options)
         case _ =>
           shouldStop = shouldStop && parser.hasNext
       }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -17,7 +17,7 @@ package com.databricks.spark.xml.util
 
 import java.io.ByteArrayInputStream
 import javax.xml.stream.events._
-import javax.xml.stream.{XMLStreamException, XMLStreamConstants, XMLEventReader, XMLInputFactory}
+import javax.xml.stream.{XMLStreamException, XMLEventReader, XMLInputFactory}
 
 import org.slf4j.LoggerFactory
 
@@ -88,7 +88,7 @@ private[xml] object InferSchema {
         val parser = factory.createXMLEventReader(reader)
         try {
           val rootAttributes = {
-            val rootEvent = skipUntil(parser, XMLStreamConstants.START_ELEMENT)
+            val rootEvent = skipUntil(parser, classOf[StartElement])
             rootEvent.asStartElement.getAttributes
               .map(_.asInstanceOf[Attribute]).toArray
           }
@@ -140,11 +140,11 @@ private[xml] object InferSchema {
           case _: EndElement if options.treatEmptyValuesAsNulls => NullType
           case _: EndElement => StringType
           case _: StartElement => inferObject(parser, options)
-          case _: Characters => inferTypeFromString(readData(parser))
+          case _: Characters => inferTypeFromString(readDataFully(parser))
         }
       case c: Characters if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
         // This means data exists
-        inferTypeFromString(readData(parser))
+        inferTypeFromString(readDataFully(parser))
 
       case e: XMLEvent =>
         sys.error(s"Failed to parse data with unexpected event ${e.toString}")

--- a/src/test/resources/books.xml
+++ b/src/test/resources/books.xml
@@ -6,8 +6,26 @@
       <genre>Computer</genre>
       <price>44.95</price>
       <publish_date>2000-10-01</publish_date>
-      <description>An in-depth look at creating applications 
-      with XML.</description>
+      <description>
+
+
+         An in-depth look at creating applications
+         with XML.This manual describes Oracle XML DB, and how you can use it to store, generate, manipulate, manage,
+         and query XML data in the database.
+
+
+         After introducing you to the heart of Oracle XML DB, namely the XMLType framework and Oracle XML DB repository,
+         the manual provides a brief introduction to design criteria to consider when planning your Oracle XML DB
+         application. It provides examples of how and where you can use Oracle XML DB.
+
+
+         The manual then describes ways you can store and retrieve XML data using Oracle XML DB, APIs for manipulating
+         XMLType data, and ways you can view, generate, transform, and search on existing XML data. The remainder of
+         the manual discusses how to use Oracle XML DB repository, including versioning and security,
+         how to access and manipulate repository resources using protocols, SQL, PL/SQL, or Java, and how to manage
+         your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and
+         Oracle Streams Advanced Queuing XMLType support.
+      </description>
    </book>
    <book id="bk102">
       <author>Ralls, Kim</author>

--- a/src/test/resources/books.xml
+++ b/src/test/resources/books.xml
@@ -27,6 +27,9 @@
          Oracle Streams Advanced Queuing XMLType support.
       </description>
    </book>
+
+
+
    <book id="bk102">
       <author>Ralls, Kim</author>
       <title>Midnight Rain</title>

--- a/src/test/resources/books.xml
+++ b/src/test/resources/books.xml
@@ -26,11 +26,7 @@
          your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and
          Oracle Streams Advanced Queuing XMLType support.
       </description>
-   </book>
-
-
-
-   <book id="bk102">
+   </book><book id="bk102">
       <author>Ralls, Kim</author>
       <title>Midnight Rain</title>
       <genre>Fantasy</genre>

--- a/src/test/resources/books.xml
+++ b/src/test/resources/books.xml
@@ -25,8 +25,7 @@
          how to access and manipulate repository resources using protocols, SQL, PL/SQL, or Java, and how to manage
          your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and
          Oracle Streams Advanced Queuing XMLType support.
-      </description>
-   </book><book id="bk102">
+      </description></book><book id="bk102">
       <author>Ralls, Kim</author>
       <title>Midnight Rain</title>
       <genre>Fantasy</genre>


### PR DESCRIPTION
#76 
Multuple `Characters` can exist and therefore this library should be able to read the data all.
Currently, when the data is big and contains newlines, it reads only some parts of data or it fails.

This PR lets this library read character events. 