### PR TITLE
Fix bugs while reading a field of mixed type elements due to structure conversion.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-xml"
 
-version := "0.3.1"
+version := "0.3.2-SNAPSHOT"
 
 organization := "com.databricks"
 

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -1,7 +1,7 @@
 package com.databricks.spark.xml.parsers
 
 import javax.xml.stream.XMLEventReader
-import javax.xml.stream.events.{Characters, StartElement, EndElement, XMLEvent}
+import javax.xml.stream.events._
 
 import com.databricks.spark.xml.XmlOptions
 
@@ -54,4 +54,23 @@ private[xml] object StaxXmlParserUtils {
     }
   }
 
+  /**
+   * Produce values map from given attributes.
+   */
+  def toValuesMap(attributes: Array[Attribute], options: XmlOptions): Map[String, String] = {
+    if (options.excludeAttributeFlag) {
+      Map.empty[String, String]
+    } else {
+      val attrFields = attributes.map(options.attributePrefix + _.getName.getLocalPart)
+      val attrValues = attributes.map(_.getValue)
+      val nullSafeValues = {
+        if (options.treatEmptyValuesAsNulls) {
+          attrValues.map (v => if (v.trim.isEmpty) null else v)
+        } else {
+          attrValues
+        }
+      }
+      attrFields.zip(nullSafeValues).toMap
+    }
+  }
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -18,7 +18,7 @@ private[xml] object StaxXmlParserUtils {
   }
 
   /**
-   * Read the data for all continuous character events within an element.
+   * Reads the data for all continuous character events within an element.
    */
   def readDataFully(parser: XMLEventReader): String = {
     var event = parser.peek
@@ -32,7 +32,7 @@ private[xml] object StaxXmlParserUtils {
   }
 
   /**
-   * Check if current event points the EndElement.
+   * Checks if current event points the EndElement.
    */
   def checkEndElement(parser: XMLEventReader, options: XmlOptions): Boolean = {
     val current = parser.peek
@@ -55,7 +55,7 @@ private[xml] object StaxXmlParserUtils {
   }
 
   /**
-   * Produce values map from given attributes.
+   * Produces values map from given attributes.
    */
   def toValuesMap(attributes: Array[Attribute], options: XmlOptions): Map[String, String] = {
     if (options.excludeAttributeFlag) {

--- a/src/test/resources/cars-mixed-attr-no-child.xml
+++ b/src/test/resources/cars-mixed-attr-no-child.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <date type="string">2012-12-01</date>
+        <make>Tesla</make>
+        <model>S</model>
+        <comment>No comment</comment>
+    </ROW>
+    <ROW>
+        <date type="struct">
+            <year>2012</year>>
+            <month>11</month>
+            <day>2</day>
+        </date>
+        <make>Ford</make>
+        <model>E350</model>
+        <comment>Go get one now they are going fast</comment>
+    </ROW>
+    <ROW>
+        <year>2015</year>
+        <make>Chevy</make>
+        <model>Volt</model>
+        <comment>No</comment>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -87,6 +87,10 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .select("date")
       .collect()
 
+    val attrValOne = results(0).get(0).asInstanceOf[Row](1)
+    val attrValTwo = results(1).get(0).asInstanceOf[Row](1)
+    assert(attrValOne == "string")
+    assert(attrValTwo == "struct")
     assert(results.size === numCars)
   }
 

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -87,12 +87,6 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .select("date")
       .collect()
 
-    sqlContext
-      .xmlFile(carsMixedAttrNoChildFile).printSchema()
-
-    sqlContext
-      .xmlFile(carsMixedAttrNoChildFile).collect.foreach(println)
-
     assert(results.size === numCars)
   }
 

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -40,6 +40,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val carsFile8859 = "src/test/resources/cars-iso-8859-1.xml"
   val carsFileGzip = "src/test/resources/cars.xml.gz"
   val carsFileBzip2 = "src/test/resources/cars.xml.bz2"
+  val carsMixedAttrNoChildFile = "src/test/resources/cars-mixed-attr-no-child.xml"
   val booksAttributesInNoChild = "src/test/resources/books-attributes-in-no-child.xml"
   val carsUnbalancedFile = "src/test/resources/cars-unbalanced-elements.xml"
   val carsMalformedFile = "src/test/resources/cars-malformed.xml"
@@ -76,6 +77,21 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .xmlFile(carsFile)
       .select("year")
       .collect()
+
+    assert(results.size === numCars)
+  }
+
+  test("DSL test with mixed elements (attributes, no child)") {
+    val results = sqlContext
+      .xmlFile(carsMixedAttrNoChildFile)
+      .select("date")
+      .collect()
+
+    sqlContext
+      .xmlFile(carsMixedAttrNoChildFile).printSchema()
+
+    sqlContext
+      .xmlFile(carsMixedAttrNoChildFile).collect.foreach(println)
 
     assert(results.size === numCars)
   }


### PR DESCRIPTION
The XML is having mixed type of field , `date`. In this case, due to structure conversion, it sometimes does not set the value properly (it sets `null`s).

```xml
...
    <ROW>
        <date type="string">2012-12-01</date>
    </ROW>
    <ROW>
        <date type="struct">
            <year>2012</year>>
            <month>11</month>
            <day>2</day>
        </date>
    </ROW>
...
```

So, this PR fixes this bug to properly set the values.