### PR TITLE
Update Hadoop version for Spark 1.6.0 (different Hadoop versions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ matrix:
     # Spark 1.6.0
     - jdk: openjdk7
       scala: 2.10.5
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.6.0"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
+      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.6.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION assembly


### PR DESCRIPTION
This PR simply modifies Hadoop versions for Spark 1.6.0.