### PR TITLE
XML factory per partition instead of each row and reduce peek() call

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -59,9 +59,12 @@ private[xml] object StaxXmlGenerator {
           }
         case _ if name.startsWith(options.attributePrefix) =>
           writer.writeAttribute(name.substring(options.attributePrefix.length), v.toString)
+
         // For ArrayType, we just need to write each as XML element.
         case (ArrayType(ty, _), v: Seq[_]) =>
-          v.foreach(e => writeChildElement(name, ty, e))
+          v.foreach { e =>
+            writeChildElement(name, ty, e)
+          }
         // For other datatypes, we just write normal elements.
         case _ =>
           writeChildElement(name, dt, v)
@@ -94,13 +97,21 @@ private[xml] object StaxXmlGenerator {
         }
 
       case (MapType(kv, vt, _), mv: Map[_, _]) =>
-        mv.foreach {
+        val (attributes, elements) = mv.toSeq.partition {
+          case (f, _) => f.toString.startsWith(options.attributePrefix)
+        }
+        // We need to write attributes first before the value.
+        (attributes ++ elements).foreach {
           case (k, v) =>
             writeChild(k.toString, vt, v)
         }
 
       case (StructType(ty), r: Row) =>
-        ty.zip(r.toSeq).foreach {
+        val (attributes, elements) = ty.zip(r.toSeq).partition {
+          case (f, _) => f.name.startsWith(options.attributePrefix)
+        }
+        // We need to write attributes first before the value.
+        (attributes ++ elements).foreach {
           case (field, v) =>
             writeChild(field.name, field.dataType, v)
         }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -34,8 +34,8 @@ private[xml] object StaxXmlGenerator {
     * @param row The row to convert
     */
   def apply(schema: StructType,
-            writer: IndentingXMLStreamWriter,
-            options: XmlOptions)(row: Row): Unit = {
+      writer: IndentingXMLStreamWriter,
+      options: XmlOptions)(row: Row): Unit = {
     def writeChildElement: (String, DataType, Any) => Unit = {
       // If this is meant to be value but in no child, write only a value
       case (_, _, null) |(_, NullType, _) if options.nullValue == null =>

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -207,19 +207,19 @@ private[xml] object StaxXmlParser {
               val dataType = schema(index).dataType
               row(index) = dataType match {
                 case st: StructType =>
-                  // The fields are sorted so `TreeMap` is used.
                   val fields = convertField(parser, st, options) match {
                     case row: Row =>
-                      TreeMap(st.map(_.name).zip(row.toSeq): _*)
+                      Map(st.map(_.name).zip(row.toSeq): _*)
                     case v if st.exists(_.name == options.valueTag) =>
                       // If this is the element having no children, then it wraps attributes
                       // with a row So, we first need to find the field name that has the real
                       // value and then push the value.
-                      TreeMap(options.valueTag -> v)
-                    case null => TreeMap()
+                      Map(options.valueTag -> v)
+                    case null => Map.empty
                   }
+                  // The fields are sorted so `TreeMap` is used.
                   val convertedValuesMap = convertValues(valuesMap, st)
-                  val row = (fields ++ convertedValuesMap).values.toSeq
+                  val row = TreeMap((fields ++ convertedValuesMap).toSeq : _*).values.toSeq
                   Row.fromSeq(row)
 
                 case ArrayType(dt: DataType, _) =>

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -216,6 +216,7 @@ private[xml] object StaxXmlParser {
                       // with a row So, we first need to find the field name that has the real
                       // value and then push the value.
                       TreeMap(options.valueTag -> v)
+                    case null => TreeMap()
                   }
                   val convertedValuesMap = convertValues(valuesMap, st)
                   val row = (fields ++ convertedValuesMap).values.toSeq

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -19,20 +19,6 @@ private[xml] object StaxXmlParserUtils {
   }
 
   /**
-   * Reads the data for all continuous character events within an element.
-   */
-  def readDataFully(parser: XMLEventReader): String = {
-    var event = parser.peek
-    var data: String = if (event.isCharacters) "" else null
-    while(event.isCharacters) {
-      data += event.asCharacters.getData
-      parser.nextEvent
-      event = parser.peek
-    }
-    data
-  }
-
-  /**
    * Checks if current event points the EndElement.
    */
   def checkEndElement(parser: XMLEventReader, options: XmlOptions): Boolean = {

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -10,9 +10,10 @@ private[xml] object StaxXmlParserUtils {
    * Skips elements until this meets the given type of a element
    */
   def skipUntil(parser: XMLEventReader, eventType: Int): XMLEvent = {
-    var event = parser.nextEvent
+    var event = parser.peek
     while(parser.hasNext && event.getEventType != eventType) {
-      event = parser.nextEvent
+      parser.nextEvent
+      event = parser.peek
     }
     event
   }
@@ -35,22 +36,15 @@ private[xml] object StaxXmlParserUtils {
    * Checks if current event points the EndElement.
    */
   def checkEndElement(parser: XMLEventReader, options: XmlOptions): Boolean = {
-    val current = parser.peek
-    current match {
+    parser.peek match {
       case _: EndElement => true
       case _: StartElement => false
-      case _: Characters =>
-        // When `Characters` is found here, we need to look further to decide
-        // if this is really `EndElement` because this can be whitespace between
-        // `EndElement` and `StartElement`.
-        val next = {
-          parser.nextEvent
-          parser.peek
-        }
-        next match {
-          case _: EndElement => true
-          case _: XMLEvent => false
-        }
+      case _: XMLEvent =>
+        // When other events are found here rather than `EndElement` or `StartElement`
+        // , we need to look further to decide if this is the end because this can be
+        // whitespace between `EndElement` and `StartElement`.
+        parser.nextEvent
+        checkEndElement(parser, options)
     }
   }
 

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -68,8 +68,7 @@ private[xml] object InferSchema {
    *   2. Merge types by choosing the lowest type necessary to cover equal keys
    *   3. Replace any remaining null fields with string, the top type
    */
-  def infer(xml: RDD[String],
-            options: XmlOptions): StructType = {
+  def infer(xml: RDD[String], options: XmlOptions): StructType = {
     require(options.samplingRatio > 0,
       s"samplingRatio ($options.samplingRatio) should be greater than 0")
     val schemaData = if (options.samplingRatio > 0.99) {
@@ -88,11 +87,10 @@ private[xml] object InferSchema {
         val reader = new ByteArrayInputStream(xml.getBytes)
         val parser = factory.createXMLEventReader(reader)
         try {
-          val rootAttributes = {
-            val rootEvent = StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
-            rootEvent.asStartElement.getAttributes
-              .map(_.asInstanceOf[Attribute]).toArray
-          }
+          StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
+          val rootEvent = parser.nextEvent()
+          val rootAttributes =
+            rootEvent.asStartElement.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           Some(inferObject(parser, options, rootAttributes))
         } catch {
           case _: XMLStreamException if !failFast =>
@@ -112,41 +110,38 @@ private[xml] object InferSchema {
     }
   }
 
-  private def inferTypeFromString(value: String): DataType = {
-    Option(value) match {
-      case Some(v) if v.isEmpty => NullType
-      case Some(v) if isLong(v) => LongType
-      case Some(v) if isInteger(v) => IntegerType
-      case Some(v) if isDouble(v) => DoubleType
-      case Some(v) if isBoolean(v) => BooleanType
-      case Some(v) if isTimestamp(v) => TimestampType
-      case Some(v) => StringType
-      case None => NullType
-    }
+  private def inferTypeFromString: String => DataType = {
+    case null => NullType
+    case v if v.isEmpty => NullType
+    case v if isLong(v) => LongType
+    case v if isInteger(v) => IntegerType
+    case v if isDouble(v) => DoubleType
+    case v if isBoolean(v) => BooleanType
+    case v if isTimestamp(v) => TimestampType
+    case v => StringType
   }
 
   private def inferField(parser: XMLEventReader, options: XmlOptions): DataType = {
-    val current = parser.peek
-    current match {
+    parser.peek match {
       case _: EndElement => NullType
       case _: StartElement => inferObject(parser, options)
-      case c: Characters if !c.isIgnorableWhiteSpace && c.isWhiteSpace =>
+      case c: Characters if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide
         // if this is really data or space between other elements.
-        val next = {
-          parser.nextEvent
-          parser.peek
+        val data = StaxXmlParserUtils.readDataFully(parser)
+        parser.peek match {
+          case _: XMLEvent if data != null && data.trim.nonEmpty =>
+            inferTypeFromString(data)
+          case _: EndElement if options.treatEmptyValuesAsNulls =>
+            NullType
+          case _: EndElement =>
+            StringType
+          case _: StartElement =>
+            inferObject(parser, options)
         }
-        next match {
-          case _: EndElement if options.treatEmptyValuesAsNulls => NullType
-          case _: EndElement => StringType
-          case _: StartElement => inferObject(parser, options)
-          case _: Characters => inferTypeFromString(StaxXmlParserUtils.readDataFully(parser))
-        }
-      case c: Characters if !c.isIgnorableWhiteSpace && !c.isWhiteSpace =>
+      case c: Characters if !c.isWhiteSpace =>
         // This means data exists
         inferTypeFromString(StaxXmlParserUtils.readDataFully(parser))
-
       case e: XMLEvent =>
         sys.error(s"Failed to parse data with unexpected event ${e.toString}")
     }
@@ -156,8 +151,8 @@ private[xml] object InferSchema {
    * Infer the type of a xml document from the parser's token stream
    */
   private def inferObject(parser: XMLEventReader,
-                          options: XmlOptions,
-                          rootAttributes: Array[Attribute] = Array()): DataType = {
+      options: XmlOptions,
+      rootAttributes: Array[Attribute] = Array()): DataType = {
     val builder = Seq.newBuilder[StructField]
     val nameToDataTypes = collection.mutable.Map.empty[String, ArrayBuffer[DataType]]
     var shouldStop = false
@@ -173,7 +168,6 @@ private[xml] object InferSchema {
 
           val attributes = e.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           val valuesMap = StaxXmlParserUtils.toValuesMap(attributes, options)
-
           val inferredType = inferField(parser, options) match {
             case st: StructType if valuesMap.nonEmpty =>
               // Merge attributes to the field
@@ -184,6 +178,7 @@ private[xml] object InferSchema {
                   nestedBuilder += StructField(f, inferTypeFromString(v), nullable = true)
               }
               StructType(nestedBuilder.result().sortBy(_.name))
+
             case dt: DataType if valuesMap.nonEmpty =>
               // We need to manually add the field for value.
               val nestedBuilder = Seq.newBuilder[StructField]
@@ -193,6 +188,7 @@ private[xml] object InferSchema {
                   nestedBuilder += StructField(f, inferTypeFromString(v), nullable = true)
               }
               StructType(nestedBuilder.result().sortBy(_.name))
+
             case dt: DataType => dt
           }
           // Add the field and datatypes so that we can check if this is ArrayType.
@@ -200,8 +196,10 @@ private[xml] object InferSchema {
           val dataTypes = nameToDataTypes.getOrElse(field, ArrayBuffer.empty[DataType])
           dataTypes += inferredType
           nameToDataTypes += (field -> dataTypes)
+
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser, options)
+
         case _ =>
           shouldStop = shouldStop && parser.hasNext
       }


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/84

Firstly, the XML factory was being created for each row. Although this factory cannot be reused across the tasks because it is not serializable, it still can create the factory for each partition.

Secondly, It looks `peek()` is called multiple times for reading a complete data within an element. However, `IS_COALESCING` option for XML parser allows this to read only once.

Also, While looking through this library, I found some stylistic corrections and useless logics. I removed them.
1. I used `isIgnorableWhiteSpace()` so that it can differentiate some spaces between elements but it looks this function does not detect anything due to DTD is not accessible during parsing each row.
2. Corrected the indentations of parameters in function across multiple lines.
3. Removed duplicated logics.
4. Corrected `StaxXmlGenerator` to write attributes first always for safety (to prevent to try to write some data within an element first and then write attributes, which emits an exception)
