### PR TITLE
Handling inconsistent element attributes

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -193,7 +193,7 @@ private[xml] object StaxXmlParser {
         // with a row So, we first need to find the field name that has the real
         // value and then push the value.
         val valuesMap = schema.fieldNames.map((_, null)).toMap
-        Map(options.valueTag -> v) ++ valuesMap
+        valuesMap + (options.valueTag -> v)
       case _ => Map.empty
     }
     // The fields are sorted so `TreeMap` is used.

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -188,11 +188,12 @@ private[xml] object StaxXmlParser {
     val fields = convertField(parser, schema, options) match {
       case row: Row =>
         Map(schema.map(_.name).zip(row.toSeq): _*)
-      case v if schema.exists(_.name == options.valueTag) =>
+      case v if schema.fieldNames.contains(options.valueTag) =>
         // If this is the element having no children, then it wraps attributes
         // with a row So, we first need to find the field name that has the real
         // value and then push the value.
-        Map(options.valueTag -> v)
+        val valuesMap = schema.fieldNames.map((_, null)).toMap
+        Map(options.valueTag -> v) ++ valuesMap
       case _ => Map.empty
     }
     // The fields are sorted so `TreeMap` is used.

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -104,6 +104,22 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.size === numCars)
   }
 
+  test("DSL test for inconsistent element attributes as fields") {
+    val results = sqlContext
+      .xmlFile(booksAttributesInNoChild, rowTag = booksTag)
+      .select("price")
+
+    // This should not throw an exception `java.lang.ArrayIndexOutOfBoundsException`
+    // as non-existing values are represented as `null`s.
+    val nullValue = results
+      .collect()
+      .toSeq.head
+      .toSeq.head
+      .asInstanceOf[Row]
+      .get(1)
+    assert(nullValue == null)
+  }
+
   test("DSL test with elements in array having attributes") {
     val results = sqlContext.xmlFile(agesFile, rowTag = agesTag).collect()
     val attrValOne = results(0).get(0).asInstanceOf[Row](1)


### PR DESCRIPTION
#93 #94

The size of the nested row for that case itself was different with the schema. So, when it accesses to the fields, it emits `java.lang.ArrayIndexOutOfBoundsException` exception as described in the issue above.

This PR sets `null` explicitly for the fields as well like the other field so that there is no inconsistent fields.