### PR TITLE
Merge inferred types correctly for elements having no child but attributes

### DIFF
--- a/src/test/resources/books-attributes-in-no-child.xml
+++ b/src/test/resources/books-attributes-in-no-child.xml
@@ -3,7 +3,7 @@
    <book id="bk101">
       <author>Gambardella, Matthew</author>
       <title>XML Developer's Guide</title>
-      <price>44.95</price>
+      <price>twenty</price>
       <publish_date>2000-10-01</publish_date>
    </book>
    <book id="bk102">

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -546,7 +546,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       StructField(s"${attributePrefix}id", StringType, nullable = true),
       StructField("author", StringType, nullable = true),
       StructField("price", StructType(
-        List(StructField(valueTag, DoubleType, nullable = true),
+        List(StructField(valueTag, StringType, nullable = true),
           StructField(s"${attributePrefix}unit", StringType, nullable = true))),
         nullable = true),
       StructField("publish_date", StringType, nullable = true),


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/72
This PR corrects type inference so that this can find a proper compatible type from two different types when the field corresponding with `valueTag`.

Currently, this library infers the schema having duplicated fields corresponding with `valueTag` when the types are different.
Since one of the original tests is related with this, I just correct the test and the data.