### PR TITLE
Add short name compressions at documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When writing files the API accepts several options:
 * `nullValue`: The value to write `null` value. Default is string `null`. When this is `null`, it does not write attributes and elements for fields.
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `@`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `#VALUE`.
-* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`. Defaults to no compression when a codec is not specified.
+* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 
 Currently it supports the shorten name useage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
 

--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.types.{StructType, StructField, StringType, DoubleType};
 
 val sqlContext = new SQLContext(sc)
-val customSchema = StructType(
+val customSchema = StructType(Array(
     StructField("@id", StringType, nullable = true),
     StructField("author", StringType, nullable = true),
     StructField("description", StringType, nullable = true),
     StructField("genre", StringType ,nullable = true),
     StructField("price", DoubleType, nullable = true),
     StructField("publish_date", StringType, nullable = true),
-    StructField("title", StringType, nullable = true))
+    StructField("title", StringType, nullable = true)))
 
 
 val df = sqlContext.read
@@ -240,14 +240,14 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
 
 val sqlContext = new SQLContext(sc)
-val customSchema = StructType(
+val customSchema = StructType(Array(
     StructField("@id", StringType, nullable = true),
     StructField("author", StringType, nullable = true),
     StructField("description", StringType, nullable = true),
     StructField("genre", StringType ,nullable = true),
     StructField("price", DoubleType, nullable = true),
     StructField("publish_date", StringType, nullable = true),
-    StructField("title", StringType, nullable = true))
+    StructField("title", StringType, nullable = true)))
 
 val df = sqlContext.load(
     "com.databricks.spark.xml",


### PR DESCRIPTION
This PR simply adds the description for short-name compression codecs in documentation.