### PR TITLE
Always Ignore XML comments wherever it is

### DIFF
--- a/src/test/resources/cars.xml
+++ b/src/test/resources/cars.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <ROWSET>
     <ROW>
-        <year>2012</year>
+        <year>2012<!--A comment within tags--></year>
         <make>Tesla</make>
         <model>S</model>
         <comment>No comment</comment>
     </ROW>
     <ROW>
-        <year>1997</year>
+        <year>1997</year><!--A comment within elements-->
         <make>Ford</make>
         <model>E350</model>
-        <comment>Go get one now they are going fast</comment>
+        <comment><!--A comment before a value-->Go get one now they are going fast</comment>
     </ROW>
     <ROW>
         <year>2015</year>


### PR DESCRIPTION
#100 

After looking into CSV and JSON datasources, it looks okay to always ignore XML comments for now.

This could be pretty simply done by using `EventFilter` in StAX parser.

This PR ignore comments within XML documents.

For example, `printSchema()` on the data below:

```xml
 <ROWSET>
     <ROW>
       <a>2012<!--A comment within tags--></a>
     </ROW>
  ...
```

produces

- **Before**

```scala
java.lang.RuntimeException: Failed to parse data with unexpected event <!--A comment before a value-->
	at scala.sys.package$.error(package.scala:27)
	at com.databricks.spark.xml.util.InferSchema$.inferField(InferSchema.scala:151)
	at com.databricks.spark.xml.util.InferSchema$.com$databricks$spark$xml$util$InferSchema$$inferObject(InferSchema.scala:178)
	at com.databricks.spark.xml.util.InferSchema$$anonfun$3$$anonfun$apply$2.apply(InferSchema.scala:101)
	at com.databricks.spark.xml.util.InferSchema$$anonfun$3$$anonfun$apply$2.apply(InferSchema.scala:89)
```

- **After**

```bash
root
 |-- a: long (nullable = true)
```
