### PR TITLE
Issue 117 - No value in nested struct causes arrayIndexOutOfBounds

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -214,7 +214,7 @@ private[xml] object StaxXmlParser {
     // The fields are sorted so `TreeMap` is used.
     val convertedValuesMap = convertValues(valuesMap, schema)
     val row = TreeMap((fields ++ convertedValuesMap).toSeq : _*).values.toSeq
-    Row.fromSeq(row)
+    if(row.length == 0) null else Row.fromSeq(row)
   }
 
   /**

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -214,7 +214,9 @@ private[xml] object StaxXmlParser {
     // The fields are sorted so `TreeMap` is used.
     val convertedValuesMap = convertValues(valuesMap, schema)
     val row = TreeMap((fields ++ convertedValuesMap).toSeq : _*).values.toSeq
-    if(row.length == 0) null else Row.fromSeq(row)
+    // Return null rather than empty row. For nested structs empty row causes
+    // ArrayOutOfBounds exceptions when executing an action
+    if(row.isEmpty) null else Row.fromSeq(row)
   }
 
   /**

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -22,6 +22,7 @@
 		<b>
 			<c>c</c>
 			<d>0.4</d>
+			<!-- Issue 117 - This is where an empty Row would be produced instead of null -->
 			<es></es>
 		</b>
 		<f>f</f>

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<root>
+	<item>
+		<a>a</a>
+		<b>
+			<c>c</c>
+			<d>0.4</d>
+			<es>
+				<e>
+					<ee>1</ee>
+				</e>
+				<e>
+					<ee>2</ee>
+					<eee>3</eee>
+				</e>
+			</es>
+		</b>
+		<f>f</f>
+	</item>
+	<item>
+		<a>a</a>
+		<b>
+			<c>c</c>
+			<d>0.4</d>
+			<es></es>
+		</b>
+		<f>f</f>
+	</item>
+</root>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.{SparkException, SparkContext}
 import org.apache.spark.sql.{SaveMode, Row, SQLContext}
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions._
-import scala.collection.mutable.WrappedArray
 
 class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val tempEmptyDir = "target/test/empty/"
@@ -666,7 +665,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     val firstES = result(0)(0)
       .asInstanceOf[Row](0)
-      .asInstanceOf[WrappedArray[Row]]
+      .asInstanceOf[Seq[Row]]
     assert(firstES(0).asInstanceOf[Row].toSeq === Seq(1, null) )
     assert(firstES(1).asInstanceOf[Row].toSeq === Seq(2, 3) )
 

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -657,19 +657,19 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     assert(results.size === numTopics)
   }
-  
+
   test("Missing nested struct") {
     val result = sqlContext
-      .xmlFile(nullNestedStructFile, rowTag="item")
+      .xmlFile(nullNestedStructFile, rowTag = "item")
       .select("b.es")
       .collect()
-      
+
     val firstES = result(0)(0)
       .asInstanceOf[Row](0)
       .asInstanceOf[WrappedArray[Row]]
     assert(firstES(0).asInstanceOf[Row].toSeq === Seq(1, null) )
     assert(firstES(1).asInstanceOf[Row].toSeq === Seq(2, 3) )
-    
-    assert(result(1).toSeq === Seq(null))  
+
+    assert(result(1).toSeq === Seq(null))
   }
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -657,7 +657,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.size === numTopics)
   }
 
-  test("Missing nested struct") {
+  test("Missing nested struct represented as null instead of empty Row") {
     val result = sqlContext
       .xmlFile(nullNestedStructFile, rowTag = "item")
       .select("b.es")


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/117

Added a check into convertRow function to return null instead
of empty Row object.

This will ensure that Spark doesn't throw ArrayIndexOutOfBounds
when there's no value in a nested struct.

Change-Id: Id796de2b861868543b7fc6e95a6cd56567be5d47
Signed-off-by: Jan Scherbaum <kmoj02@gmail.com>