### PR TITLE
Changes for 0.3.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ You can link against this library in your program at the following coordinates:
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.10
-version: 0.3.3
+version: 0.3.4
 ```
 ### Scala 2.11
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.11
-version: 0.3.3
+version: 0.3.4
 ```
 
 ## Using with Spark shell
@@ -34,12 +34,12 @@ This package can be added to  Spark using the `--packages` command line option. 
 
 ### Spark compiled with Scala 2.10
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.3.3
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.3.4
 ```
 
 ### Spark compiled with Scala 2.11
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.3
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.4
 ```
 
 ## Features
@@ -436,7 +436,7 @@ Automatically infer schema (data types)
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.3.3" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.3.4" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 
 df <- read.df(sqlContext, "books.xml", source = "com.databricks.spark.xml", rowTag = "book")
@@ -449,7 +449,7 @@ You can manually specify schema:
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.3.3" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.3.4" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 customSchema <- structType(
     structField("@id", "string"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-xml"
 
-version := "0.3.3"
+version := "0.3.4"
 
 organization := "com.databricks"
 


### PR DESCRIPTION
This PR prepares the release for 0.3.4.

This will include the changes below:

- Produces correct order of columns for nested rows when user specifies a schema https://github.com/databricks/spark-xml/commit/527b97692a54c6900771a0e9afc57d0e38534452
- No value in nested struct causes arrayIndexOutOfBounds (https://github.com/databricks/spark-xml/commit/19eb2779cf232dc0239e54bf353fa609c8b05231)
- `compression` aslias for `codec` option https://github.com/databricks/spark-xml/pull/145
- Remove dead codes, https://github.com/databricks/spark-xml/pull/144
- Fix nested element with name of parent bug, https://github.com/databricks/spark-xml/pull/161
- Minor documentation changes - https://github.com/databricks/spark-xml/pull/159 and https://github.com/databricks/spark-xml/pull/143
- Ignore comments even when it is surrounded white spaces https://github.com/databricks/spark-xml/pull/166