### PR TITLE
[fix] Self-closing tags are not supported as top-level rows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 name := "spark-xml"
 
-version := "0.3.3"
+version := "0.3.4"
 
 organization := "com.databricks"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.10.5"
 
 spName := "databricks/spark-xml"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 
-sparkVersion := "1.6.0"
+sparkVersion := "1.6.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -58,7 +58,6 @@ class DefaultSource
       val options = XmlOptions(parameters)
       (options.charset, options.rowTag)
     }
-
     XmlRelation(
       () => XmlFile.withCharset(sqlContext.sparkContext, path, charset, rowTag),
       Some(path),

--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -86,7 +86,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
     endEmptyTag = "/>".getBytes(charset)
     space = " ".getBytes(charset)
     angleBracket = ">".getBytes(charset)
-    tagPattern = ("\\"+new String(startTag).substring(0,new String(startTag).length-1)+"(\\W)(.*)(\\W)*\\<(.*)(\\W)(.*)\\>").r
+    tagPattern = ("\\"+new String(startTag).substring(0,new String(startTag).length-1)+"([^\\>]*)").r
     require(startTag != null, "Start tag cannot be null.")
     require(endTag != null, "End tag cannot be null.")
     require(endEmptyTag != null, "End Empty tag cannot be null.")    
@@ -160,7 +160,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
       try {
         buffer.write(currentStartTag)
         if (readUntilMatch(endTag, withinBlock = true, force = false)) {
-          if(tagPattern.findAllIn(new String(buffer.getData)).length>0){
+          if(!tagPattern.findFirstIn(new String(buffer.getData)).get.takeRight(1).equals("/")){
             if (readUntilMatch(endTag, withinBlock = true, force = true)) {              
           	  key.set(filePosition.getPos)
           	  value.set(buffer.getData, 0, buffer.getLength)            

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -80,6 +80,7 @@ private[xml] object StaxXmlParser {
           case _: XMLStreamException if !failFast =>
             logger.warn(s"Dropping malformed row: ${xml.replaceAll("\n", "")}")
             None
+          case _: Exception => None
         }
       }
     }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -11,7 +11,7 @@ private[xml] object StaxXmlParserUtils {
    */
   def skipUntil(parser: XMLEventReader, eventType: Int): XMLEvent = {
     var event = parser.peek
-    while(parser.hasNext && event.getEventType != eventType) {
+    while (parser.hasNext && event.getEventType != eventType) {
       event = parser.nextEvent
     }
     event
@@ -21,24 +21,38 @@ private[xml] object StaxXmlParserUtils {
    * Checks if current event points the EndElement.
    */
   def checkEndElement(parser: XMLEventReader): Boolean = {
-    parser.peek match {
-      case _: EndElement => true
-      case _: StartElement => false
-      case _ =>
-        // When other events are found here rather than `EndElement` or `StartElement`
-        // , we need to look further to decide if this is the end because this can be
-        // whitespace between `EndElement` and `StartElement`.
-        parser.nextEvent
-        checkEndElement(parser)
+    if (parser.hasNext()) {
+      parser.peek match {
+        case _: EndElement => {
+          true
+        }
+        case _: StartElement => {
+          false
+        }
+        case _ => {
+          // When other events are found here rather than `EndElement` or `StartElement`
+          // , we need to look further to decide if this is the end because this can be
+          // whitespace between `EndElement` and `StartElement`.
+          if (parser.hasNext()) {
+            parser.nextEvent
+            checkEndElement(parser)
+          } else {
+            true
+          }
+        }
+      }
+    } else {
+      true
     }
+
   }
 
   /**
    * Produces values map from given attributes.
    */
   def convertAttributesToValuesMap(
-      attributes: Array[Attribute],
-      options: XmlOptions): Map[String, String] = {
+    attributes: Array[Attribute],
+    options: XmlOptions): Map[String, String] = {
     if (options.excludeAttributeFlag) {
       Map.empty[String, String]
     } else {
@@ -46,7 +60,7 @@ private[xml] object StaxXmlParserUtils {
       val attrValues = attributes.map(_.getValue)
       val nullSafeValues = {
         if (options.treatEmptyValuesAsNulls) {
-          attrValues.map (v => if (v.trim.isEmpty) null else v)
+          attrValues.map(v => if (v.trim.isEmpty) null else v)
         } else {
           attrValues
         }
@@ -54,7 +68,6 @@ private[xml] object StaxXmlParserUtils {
       attrFields.zip(nullSafeValues).toMap
     }
   }
-
 
   /**
    * Convert the current structure of XML document to a XML string.

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -162,6 +162,7 @@ private[xml] object InferSchema {
     val builder = Seq.newBuilder[StructField]
     val nameToDataType = collection.mutable.Map.empty[String, ArrayBuffer[DataType]]
     var shouldStop = false
+
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
@@ -211,6 +212,7 @@ private[xml] object InferSchema {
           shouldStop = shouldStop && parser.hasNext
       }
     }
+
     // We need to manually merges the fields having the sames so that
     // This can be inferred as ArrayType.
     nameToDataType.foreach{


### PR DESCRIPTION
fix bug of Self-closing in top-level rows

test with :

xml file content 

```
<?xml version='1.0' encoding='UTF-8'?>
<parentNode version="0.6">
  <child id="122944" version="11"/>
  <child id="122945" version="11"/>
  <child id="122946" version="12"/>
  <child id="122954" version="11">
    <tag k="toto" v="titi"/>
    <tag k="toto2" v="titi2"/>
  </child>  
</parentNode>
```

Java code

```
DataFrame lines = sqlContext
            .read()
            .format("com.databricks.spark.xml")
            .option("rowTag", "child")
            .load(filePathNodes)
lines.printSchema();
lines.show();
```
