### PR TITLE
Upgrade spark 2.0 and prepare 0.4.0-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.7.0" TEST_SPARK_VERSION="2.0.0"
+      env: TEST_HADOOP_VERSION="2.6.0" TEST_SPARK_VERSION="2.0.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION assembly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,13 @@ cache:
     - $HOME/.ivy2
 matrix:
   include:
-    # Spark 1.3.0
-    - jdk: openjdk6
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.3.0"
-    - jdk: openjdk6
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.3.0"
-    # Spark 1.4.1
-    # We only test Spark 1.4.1 with Hadooop 2.2.0 because
-    # https://github.com/apache/spark/pull/6599 is not present in 1.4.1,
-    # so the published Spark Maven artifacts will not work with Hadoop 1.x.
-    - jdk: openjdk6
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
-    # Spark 1.5.0
+    # Spark 2.0.0
     - jdk: openjdk7
       scala: 2.10.5
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0"
-    # Spark 1.6.0
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.6.0"
+      env: TEST_HADOOP_VERSION="2.7.0" TEST_SPARK_VERSION="2.0.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION assembly

--- a/README.md
+++ b/README.md
@@ -10,23 +10,28 @@ The structure and test tools are mostly copied from [CSV Data Source for Spark](
 
 ## Requirements
 
-This library requires Spark 1.3+
+This library requires Spark 2.0+ for 0.4.x.
+
+For version that works with Spark 1.x, please check for [branch-0.3](https://github.com/databricks/spark-xml/tree/branch-0.3).
 
 
 ## Linking
 You can link against this library in your program at the following coordinates:
 
 ### Scala 2.10
+
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.10
-version: 0.3.4
+version: 0.4.0
 ```
+
 ### Scala 2.11
+
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.11
-version: 0.3.4
+version: 0.4.0
 ```
 
 ## Using with Spark shell
@@ -34,12 +39,12 @@ This package can be added to  Spark using the `--packages` command line option. 
 
 ### Spark compiled with Scala 2.10
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.3.4
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.4.0
 ```
 
 ### Spark compiled with Scala 2.11
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.4
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.4.0
 ```
 
 ## Features
@@ -173,7 +178,6 @@ OPTIONS (path "books.xml", rowTag "book")
 ```
 
 ### Scala API
-__Spark 1.4+:__
 
 ```scala
 import org.apache.spark.sql.SQLContext
@@ -222,50 +226,7 @@ selectedData.write
     .save("newbooks.xml")
 ```
 
-__Spark 1.3:__
-
-```scala
-import org.apache.spark.sql.SQLContext
-
-val sqlContext = new SQLContext(sc)
-val df = sqlContext.load(
-    "com.databricks.spark.xml",
-    Map("path" -> "books.xml", "rowTag" -> "book"))
-
-val selectedData = df.select("author", "_id")
-selectedData.save("com.databricks.spark.xml",
-	SaveMode.ErrorIfExists,
-	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
-```
-
-You can manually specify the schema when reading data:
-```scala
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
-
-val sqlContext = new SQLContext(sc)
-val customSchema = StructType(Array(
-    StructField("_id", StringType, nullable = true),
-    StructField("author", StringType, nullable = true),
-    StructField("description", StringType, nullable = true),
-    StructField("genre", StringType ,nullable = true),
-    StructField("price", DoubleType, nullable = true),
-    StructField("publish_date", StringType, nullable = true),
-    StructField("title", StringType, nullable = true)))
-
-val df = sqlContext.load(
-    "com.databricks.spark.xml",
-    schema = customSchema,
-    Map("path" -> "books.xml", "rowTag" -> "book"))
-
-val selectedData = df.select("author", "_id")
-selectedData.save("com.databricks.spark.xml",
-	SaveMode.ErrorIfExists,
-	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
-```
-
 ### Java API
-__Spark 1.4+:__
 
 ```java
 import org.apache.spark.sql.SQLContext
@@ -312,58 +273,8 @@ df.select("author", "_id").write()
     .save("newbooks.xml");
 ```
 
-
-
-__Spark 1.3:__
-
-```java
-import org.apache.spark.sql.SQLContext
-
-SQLContext sqlContext = new SQLContext(sc);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("path", "books.xml");
-DataFrame df = sqlContext.load("com.databricks.spark.xml", options);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("rootTag", "books");
-options.put("path", "newbooks.xml");
-df.select("author", "_id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
-```
-
-You can manually specify schema:
-```java
-import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.types.*;
-
-SQLContext sqlContext = new SQLContext(sc);
-StructType customSchema = new StructType(new StructField[] {
-    new StructField("_id", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("author", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("description", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("genre", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("price", DataTypes.DoubleType, true, Metadata.empty()),
-    new StructField("publish_date", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("title", DataTypes.StringType, true, Metadata.empty())
-});
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("path", "books.xml");
-DataFrame df = sqlContext.load("com.databricks.spark.xml", customSchema, options);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("rootTag", "books");
-options.put("path", "newbooks.xml");
-df.select("author", "_id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
-```
-
 ### Python API
 
-__Spark 1.4+:__
 
 ```python
 from pyspark.sql import SQLContext
@@ -402,45 +313,13 @@ df.select("author", "_id").write \
     .save('newbooks.xml')
 ```
 
-
-__Spark 1.3:__
-
-```python
-from pyspark.sql import SQLContext
-sqlContext = SQLContext(sc)
-
-df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', path = 'books.xml')
-df.select("author", "_id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
-```
-
-You can manually specify schema:
-```python
-from pyspark.sql import SQLContext
-from pyspark.sql.types import *
-
-sqlContext = SQLContext(sc)
-customSchema = StructType([ \
-    StructField("_id", StringType(), True), \
-    StructField("author", StringType(), True), \
-    StructField("description", StringType(), True), \
-    StructField("genre", StringType(), True), \
-    StructField("price", DoubleType(), True), \
-    StructField("publish_date", StringType(), True), \
-    StructField("title", StringType(), True)])
-
-df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', schema = customSchema, path = 'books.xml')
-df.select("author", "_id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
-```
-
-
 ### R API
-__Spark 1.4+:__
 
 Automatically infer schema (data types)
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.3.4" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.4.0" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 
 df <- read.df(sqlContext, "books.xml", source = "com.databricks.spark.xml", rowTag = "book")
@@ -453,7 +332,7 @@ You can manually specify schema:
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.3.4" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.4.0" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 customSchema <- structType(
     structField("_id", "string"),

--- a/README.md
+++ b/README.md
@@ -10,23 +10,25 @@ The structure and test tools are mostly copied from [CSV Data Source for Spark](
 
 ## Requirements
 
-This library requires Spark 1.3+
+This library requires Spark 2.0+ for 0.4.x. For Spark 1.3.+, 0.3.x version works with it.
 
 
 ## Linking
 You can link against this library in your program at the following coordinates:
 
 ### Scala 2.10
+
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.10
-version: 0.3.3
+version: 0.4.0-SNAPSHOT
 ```
 ### Scala 2.11
+
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.11
-version: 0.3.3
+version: 0.4.0-SNAPSHOT
 ```
 
 ## Using with Spark shell
@@ -169,7 +171,6 @@ OPTIONS (path "books.xml", rowTag "book")
 ```
 
 ### Scala API
-__Spark 1.4+:__
 
 ```scala
 import org.apache.spark.sql.SQLContext
@@ -218,50 +219,7 @@ selectedData.write
     .save("newbooks.xml")
 ```
 
-__Spark 1.3:__
-
-```scala
-import org.apache.spark.sql.SQLContext
-
-val sqlContext = new SQLContext(sc)
-val df = sqlContext.load(
-    "com.databricks.spark.xml",
-    Map("path" -> "books.xml", "rowTag" -> "book"))
-
-val selectedData = df.select("author", "@id")
-selectedData.save("com.databricks.spark.xml",
-	SaveMode.ErrorIfExists,
-	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
-```
-
-You can manually specify the schema when reading data:
-```scala
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
-
-val sqlContext = new SQLContext(sc)
-val customSchema = StructType(Array(
-    StructField("@id", StringType, nullable = true),
-    StructField("author", StringType, nullable = true),
-    StructField("description", StringType, nullable = true),
-    StructField("genre", StringType ,nullable = true),
-    StructField("price", DoubleType, nullable = true),
-    StructField("publish_date", StringType, nullable = true),
-    StructField("title", StringType, nullable = true)))
-
-val df = sqlContext.load(
-    "com.databricks.spark.xml",
-    schema = customSchema,
-    Map("path" -> "books.xml", "rowTag" -> "book"))
-
-val selectedData = df.select("author", "@id")
-selectedData.save("com.databricks.spark.xml",
-	SaveMode.ErrorIfExists,
-	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
-```
-
 ### Java API
-__Spark 1.4+:__
 
 ```java
 import org.apache.spark.sql.SQLContext
@@ -309,57 +267,7 @@ df.select("author", "@id").write()
 ```
 
 
-
-__Spark 1.3:__
-
-```java
-import org.apache.spark.sql.SQLContext
-
-SQLContext sqlContext = new SQLContext(sc);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("path", "books.xml");
-DataFrame df = sqlContext.load("com.databricks.spark.xml", options);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("rootTag", "books");
-options.put("path", "newbooks.xml");
-df.select("author", "@id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
-```
-
-You can manually specify schema:
-```java
-import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.types.*;
-
-SQLContext sqlContext = new SQLContext(sc);
-StructType customSchema = new StructType(new StructField[] {
-    new StructField("@id", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("author", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("description", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("genre", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("price", DataTypes.DoubleType, true, Metadata.empty()),
-    new StructField("publish_date", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("title", DataTypes.StringType, true, Metadata.empty())
-});
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("path", "books.xml");
-DataFrame df = sqlContext.load("com.databricks.spark.xml", customSchema, options);
-
-HashMap<String, String> options = new HashMap<String, String>();
-options.put("rowTag", "book");
-options.put("rootTag", "books");
-options.put("path", "newbooks.xml");
-df.select("author", "@id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
-```
-
 ### Python API
-
-__Spark 1.4+:__
 
 ```python
 from pyspark.sql import SQLContext
@@ -399,38 +307,7 @@ df.select("author", "@id").write \
 ```
 
 
-__Spark 1.3:__
-
-```python
-from pyspark.sql import SQLContext
-sqlContext = SQLContext(sc)
-
-df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', path = 'books.xml')
-df.select("author", "@id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
-```
-
-You can manually specify schema:
-```python
-from pyspark.sql import SQLContext
-from pyspark.sql.types import *
-
-sqlContext = SQLContext(sc)
-customSchema = StructType([ \
-    StructField("@id", StringType(), True), \
-    StructField("author", StringType(), True), \
-    StructField("description", StringType(), True), \
-    StructField("genre", StringType(), True), \
-    StructField("price", DoubleType(), True), \
-    StructField("publish_date", StringType(), True), \
-    StructField("title", StringType(), True)])
-
-df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', schema = customSchema, path = 'books.xml')
-df.select("author", "@id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
-```
-
-
 ### R API
-__Spark 1.4+:__
 
 Automatically infer schema (data types)
 ```R
@@ -492,4 +369,3 @@ This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line
 ## Acknowledgements
 
 This project was initially created by [HyukjinKwon](https://github.com/HyukjinKwon) and donated to [Databricks](https://databricks.com).
-

--- a/README.md
+++ b/README.md
@@ -10,28 +10,23 @@ The structure and test tools are mostly copied from [CSV Data Source for Spark](
 
 ## Requirements
 
-This library requires Spark 2.0+ for 0.4.x.
-
-For version that works with Spark 1.x, please check for [branch-0.3](https://github.com/databricks/spark-xml/tree/branch-0.3).
+This library requires Spark 1.3+
 
 
 ## Linking
 You can link against this library in your program at the following coordinates:
 
 ### Scala 2.10
-
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.10
-version: 0.4.0
+version: 0.3.4
 ```
-
 ### Scala 2.11
-
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.11
-version: 0.4.0
+version: 0.3.4
 ```
 
 ## Using with Spark shell
@@ -39,12 +34,12 @@ This package can be added to  Spark using the `--packages` command line option. 
 
 ### Spark compiled with Scala 2.10
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.4.0
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.3.4
 ```
 
 ### Spark compiled with Scala 2.11
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.4.0
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.3.4
 ```
 
 ## Features
@@ -178,6 +173,7 @@ OPTIONS (path "books.xml", rowTag "book")
 ```
 
 ### Scala API
+__Spark 1.4+:__
 
 ```scala
 import org.apache.spark.sql.SQLContext
@@ -226,7 +222,50 @@ selectedData.write
     .save("newbooks.xml")
 ```
 
+__Spark 1.3:__
+
+```scala
+import org.apache.spark.sql.SQLContext
+
+val sqlContext = new SQLContext(sc)
+val df = sqlContext.load(
+    "com.databricks.spark.xml",
+    Map("path" -> "books.xml", "rowTag" -> "book"))
+
+val selectedData = df.select("author", "_id")
+selectedData.save("com.databricks.spark.xml",
+	SaveMode.ErrorIfExists,
+	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
+```
+
+You can manually specify the schema when reading data:
+```scala
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
+
+val sqlContext = new SQLContext(sc)
+val customSchema = StructType(Array(
+    StructField("_id", StringType, nullable = true),
+    StructField("author", StringType, nullable = true),
+    StructField("description", StringType, nullable = true),
+    StructField("genre", StringType ,nullable = true),
+    StructField("price", DoubleType, nullable = true),
+    StructField("publish_date", StringType, nullable = true),
+    StructField("title", StringType, nullable = true)))
+
+val df = sqlContext.load(
+    "com.databricks.spark.xml",
+    schema = customSchema,
+    Map("path" -> "books.xml", "rowTag" -> "book"))
+
+val selectedData = df.select("author", "_id")
+selectedData.save("com.databricks.spark.xml",
+	SaveMode.ErrorIfExists,
+	Map("path" -> "newbooks.xml", "rootTag" -> "books", "rowTag" -> "book"))
+```
+
 ### Java API
+__Spark 1.4+:__
 
 ```java
 import org.apache.spark.sql.SQLContext
@@ -273,8 +312,58 @@ df.select("author", "_id").write()
     .save("newbooks.xml");
 ```
 
+
+
+__Spark 1.3:__
+
+```java
+import org.apache.spark.sql.SQLContext
+
+SQLContext sqlContext = new SQLContext(sc);
+
+HashMap<String, String> options = new HashMap<String, String>();
+options.put("rowTag", "book");
+options.put("path", "books.xml");
+DataFrame df = sqlContext.load("com.databricks.spark.xml", options);
+
+HashMap<String, String> options = new HashMap<String, String>();
+options.put("rowTag", "book");
+options.put("rootTag", "books");
+options.put("path", "newbooks.xml");
+df.select("author", "_id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
+```
+
+You can manually specify schema:
+```java
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.*;
+
+SQLContext sqlContext = new SQLContext(sc);
+StructType customSchema = new StructType(new StructField[] {
+    new StructField("_id", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("author", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("description", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("genre", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("price", DataTypes.DoubleType, true, Metadata.empty()),
+    new StructField("publish_date", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("title", DataTypes.StringType, true, Metadata.empty())
+});
+
+HashMap<String, String> options = new HashMap<String, String>();
+options.put("rowTag", "book");
+options.put("path", "books.xml");
+DataFrame df = sqlContext.load("com.databricks.spark.xml", customSchema, options);
+
+HashMap<String, String> options = new HashMap<String, String>();
+options.put("rowTag", "book");
+options.put("rootTag", "books");
+options.put("path", "newbooks.xml");
+df.select("author", "_id").save("com.databricks.spark.xml", SaveMode.ErrorIfExists, options)
+```
+
 ### Python API
 
+__Spark 1.4+:__
 
 ```python
 from pyspark.sql import SQLContext
@@ -313,13 +402,45 @@ df.select("author", "_id").write \
     .save('newbooks.xml')
 ```
 
+
+__Spark 1.3:__
+
+```python
+from pyspark.sql import SQLContext
+sqlContext = SQLContext(sc)
+
+df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', path = 'books.xml')
+df.select("author", "_id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
+```
+
+You can manually specify schema:
+```python
+from pyspark.sql import SQLContext
+from pyspark.sql.types import *
+
+sqlContext = SQLContext(sc)
+customSchema = StructType([ \
+    StructField("_id", StringType(), True), \
+    StructField("author", StringType(), True), \
+    StructField("description", StringType(), True), \
+    StructField("genre", StringType(), True), \
+    StructField("price", DoubleType(), True), \
+    StructField("publish_date", StringType(), True), \
+    StructField("title", StringType(), True)])
+
+df = sqlContext.load(source="com.databricks.spark.xml", rowTag = 'book', schema = customSchema, path = 'books.xml')
+df.select("author", "_id").save('newbooks.xml', rootTag = 'books', rowTag = 'book', path = 'newbooks.xml')
+```
+
+
 ### R API
+__Spark 1.4+:__
 
 Automatically infer schema (data types)
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.4.0" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-xml_2.10:0.3.4" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 
 df <- read.df(sqlContext, "books.xml", source = "com.databricks.spark.xml", rowTag = "book")
@@ -332,7 +453,7 @@ You can manually specify schema:
 ```R
 library(SparkR)
 
-Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.4.0" "sparkr-shell"')
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:0.3.4" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 customSchema <- structType(
     structField("_id", "string"),

--- a/build.sbt
+++ b/build.sbt
@@ -75,26 +75,3 @@ ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false
   else true
 }
-
-// -- MiMa binary compatibility checks ------------------------------------------------------------
-
-//import com.typesafe.tools.mima.core._
-//import com.typesafe.tools.mima.plugin.MimaKeys.binaryIssueFilters
-//import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
-//import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-//
-//mimaDefaultSettings ++ Seq(
-//  previousArtifact := Some("org.apache" %% "spark-xml" % "1.2.0"),
-//  binaryIssueFilters ++= Seq(
-//    // These classes are not intended to be public interfaces:
-//    ProblemFilters.excludePackage("org.apache.spark.xml.XmlRelation"),
-//    ProblemFilters.excludePackage("org.apache.spark.xml.util.InferSchema"),
-//    ProblemFilters.excludePackage("org.apache.spark.sql.readers"),
-//    ProblemFilters.excludePackage("org.apache.spark.xml.util.TypeCast"),
-//    // We allowed the private `XmlRelation` type to leak into the public method signature:
-//    ProblemFilters.exclude[IncompatibleResultTypeProblem](
-//      "org.apache.spark.xml.DefaultSource.createRelation")
-//  )
-//)
-
-// ------------------------------------------------------------------------------------------------

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-xml"
 
-version := "0.3.3"
+version := "0.4.0-SNAPSHOT"
 
 organization := "com.databricks"
 
@@ -10,7 +10,7 @@ spName := "databricks/spark-xml"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 
-sparkVersion := "1.6.0"
+sparkVersion := "2.0.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -20,7 +20,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-import com.databricks.spark.xml.util.CompressionCodecs
 import com.databricks.spark.xml.util.XmlFile
 
 /**

--- a/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/xml/DefaultSource.scala
@@ -90,9 +90,7 @@ class DefaultSource
     }
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      val codecClass =
-        CompressionCodecs.getCodecClass(XmlOptions(parameters).codec)
-      data.saveAsXmlFile(filesystemPath.toString, parameters, codecClass)
+      XmlFile.saveAsXmlFile(data, filesystemPath.toString, parameters)
     }
     createRelation(sqlContext, parameters, data.schema)
   }

--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -70,12 +70,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
 
   override def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {
     val fileSplit: FileSplit = split.asInstanceOf[FileSplit]
-    val conf: Configuration = {
-      // Use reflection to get the Configuration. This is necessary because TaskAttemptContext is
-      // a class in Hadoop 1.x and an interface in Hadoop 2.x.
-      val method = context.getClass.getMethod("getConfiguration")
-      method.invoke(context).asInstanceOf[Configuration]
-    }
+    val conf: Configuration = context.getConfiguration
     val charset =
       Charset.forName(conf.get(XmlInputFormat.ENCODING_KEY, XmlOptions.DEFAULT_CHARSET))
     startTag = conf.get(XmlInputFormat.START_TAG_KEY).getBytes(charset)
@@ -97,25 +92,18 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
     val codec = new CompressionCodecFactory(conf).getCodec(path)
     if (null != codec) {
       decompressor = CodecPool.getDecompressor(codec)
-      // Use reflection to get the splittable compression codec and stream. This is necessary
-      // because SplittableCompressionCodec does not exist in Hadoop 1.0.x.
-      def isSplitCompressionCodec(obj: Any) = {
-        val splittableClassName = "org.apache.hadoop.io.compress.SplittableCompressionCodec"
-        obj.getClass.getInterfaces.map(_.getName).contains(splittableClassName)
-      }
-      // Here I made separate variables to avoid to try to find SplitCompressionInputStream at
-      // runtime.
-      val (inputStream, seekable) = codec match {
-        case c: CompressionCodec if isSplitCompressionCodec(c) =>
-          // At Hadoop 1.0.x, this case would not be executed.
-          val cIn = {
-            val sc = c.asInstanceOf[SplittableCompressionCodec]
-            sc.createInputStream(fsin, decompressor, start,
-              end, SplittableCompressionCodec.READ_MODE.BYBLOCK)
-          }
+      codec match {
+        case sc: SplittableCompressionCodec =>
+          val cIn = sc.createInputStream(
+            fsin,
+            decompressor,
+            start,
+            end,
+            SplittableCompressionCodec.READ_MODE.BYBLOCK)
           start = cIn.getAdjustedStart
           end = cIn.getAdjustedEnd
-          (cIn, cIn)
+          in = cIn
+          filePosition = cIn
         case c: CompressionCodec =>
           if (start != 0) {
             // So we have a split that is only part of a file stored using
@@ -124,10 +112,9 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
               codec.getClass.getSimpleName + " compressed stream")
           }
           val cIn = c.createInputStream(fsin, decompressor)
-          (cIn, fsin)
+          in = cIn
+          filePosition = fsin
       }
-     in = inputStream
-     filePosition = seekable
     } else {
       in = fsin
       filePosition = fsin

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -24,7 +24,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources.{PrunedScan, InsertableRelation, BaseRelation, TableScan}
 import org.apache.spark.sql.types._
-import com.databricks.spark.xml.util.{CompressionCodecs, InferSchema}
+import com.databricks.spark.xml.util.{InferSchema, XmlFile}
 import com.databricks.spark.xml.parsers.StaxXmlParser
 
 case class XmlRelation protected[spark] (
@@ -106,8 +106,7 @@ case class XmlRelation protected[spark] (
               + s" to INSERT OVERWRITE a XML table:\n${e.toString}")
       }
       // Write the data. We assume that schema isn't changed, and we won't update it.
-      val codecClass = CompressionCodecs.getCodecClass(options.codec)
-      data.saveAsXmlFile(filesystemPath.toString, parameters, codecClass)
+      XmlFile.saveAsXmlFile(data, filesystemPath.toString, parameters)
     } else {
       sys.error("XML tables only support INSERT OVERWRITE for now.")
     }

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -27,6 +27,7 @@ package object xml {
    * Adds a method, `xmlFile`, to [[SQLContext]] that allows reading XML data.
    */
   implicit class XmlContext(sqlContext: SQLContext) extends Serializable {
+    @deprecated("Use DataFrameReader.read()", "0.4.0")
     def xmlFile(
         filePath: String,
         rowTag: String = XmlOptions.DEFAULT_ROW_TAG,

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -81,7 +81,12 @@ package object xml {
     def saveAsXmlFile(
         path: String, parameters: Map[String, String] = Map(),
         compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
-      XmlFile.saveAsXmlFile(dataFrame, path, parameters)
+      val mutableParams = collection.mutable.Map(parameters.toSeq: _*)
+      val safeCodec = mutableParams.get("codec")
+        .orElse(Option(compressionCodec).map(_.getCanonicalName))
+        .orNull
+      mutableParams.put("codec", safeCodec)
+      XmlFile.saveAsXmlFile(dataFrame, path, mutableParams.toMap)
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -15,17 +15,12 @@
  */
 package com.databricks.spark
 
-import java.io.CharArrayWriter
-import javax.xml.stream.XMLOutputFactory
-
 import scala.collection.Map
 
-import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import com.databricks.spark.xml.util.{CompressionCodecs, XmlFile}
-import com.databricks.spark.xml.parsers.StaxXmlGenerator
+import com.databricks.spark.xml.util.XmlFile
 
 package object xml {
   /**

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -24,7 +24,7 @@ import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import com.databricks.spark.xml.util.XmlFile
+import com.databricks.spark.xml.util.{CompressionCodecs, XmlFile}
 import com.databricks.spark.xml.parsers.StaxXmlGenerator
 
 package object xml {
@@ -82,69 +82,11 @@ package object xml {
     //   </fieldA>
     //
     // Namely, roundtrip in writing and reading can end up in different schema structure.
+    @deprecated("Use DataFrameWriter.write()", "0.4.0")
     def saveAsXmlFile(
         path: String, parameters: Map[String, String] = Map(),
         compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
-      val options = XmlOptions(parameters.toMap)
-      val startElement = s"<${options.rootTag}>"
-      val endElement = s"</${options.rootTag}>"
-      val rowSchema = dataFrame.schema
-      val indent = XmlFile.DEFAULT_INDENT
-      val rowSeparator = XmlFile.DEFAULT_ROW_SEPARATOR
-
-      val xmlRDD = dataFrame.rdd.mapPartitions { iter =>
-        val factory = XMLOutputFactory.newInstance()
-        val writer = new CharArrayWriter()
-        val xmlWriter = factory.createXMLStreamWriter(writer)
-        val indentingXmlWriter = new IndentingXMLStreamWriter(xmlWriter)
-        indentingXmlWriter.setIndentStep(indent)
-
-        new Iterator[String] {
-          var firstRow: Boolean = true
-          var lastRow: Boolean = true
-
-          override def hasNext: Boolean = iter.hasNext || firstRow || lastRow
-
-          override def next: String = {
-            if (iter.nonEmpty) {
-              val xml = {
-                StaxXmlGenerator(
-                  rowSchema,
-                  indentingXmlWriter,
-                  options)(iter.next())
-                writer.toString
-              }
-              writer.reset()
-
-              // Here it needs to add indentations for the start of each line,
-              // in order to insert the start element and end element.
-              val indentedXml = indent + xml.replaceAll(rowSeparator, rowSeparator + indent)
-              if (firstRow) {
-                firstRow = false
-                startElement + rowSeparator + indentedXml
-              } else {
-                indentedXml
-              }
-            } else {
-              indentingXmlWriter.close()
-              if (!firstRow) {
-                lastRow = false
-                endElement
-              } else {
-                // This means the iterator was initially empty.
-                firstRow = false
-                lastRow = false
-                ""
-              }
-            }
-          }
-        }
-      }
-
-      compressionCodec match {
-        case null => xmlRDD.saveAsTextFile(path)
-        case codec => xmlRDD.saveAsTextFile(path, codec)
-      }
+      XmlFile.saveAsXmlFile(dataFrame, path, parameters)
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -85,7 +85,6 @@ private[xml] object StaxXmlGenerator {
       case (ByteType, v: Byte) => writer.writeCharacters(v.toString)
       case (BooleanType, v: Boolean) => writer.writeCharacters(v.toString)
       case (DateType, v) => writer.writeCharacters(v.toString)
-      case (udt: UserDefinedType[_], v) => writeElement(udt.sqlType, udt.serialize(v))
 
       // For the case roundtrip in reading and writing XML files, [[ArrayType]] cannot have
       // [[ArrayType]] as element type. It always wraps the element with [[StructType]]. So,

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -95,7 +95,6 @@ private[xml] object StaxXmlParser {
       case dt: StructType => convertObject(parser, dt, options)
       case MapType(StringType, vt, _) => convertMap(parser, vt, options)
       case ArrayType(st, _) => convertField(parser, st, options)
-      case udt: UserDefinedType[_] => convertField(parser, udt.sqlType, options)
       case _: StringType => StaxXmlParserUtils.currentStructureAsString(parser)
     }
 
@@ -141,7 +140,7 @@ private[xml] object StaxXmlParser {
     case (v, ByteType) => castTo(v, ByteType)
     case (v, ShortType) => castTo(v, ShortType)
     case (v, IntegerType) => signSafeToInt(v)
-    case (v, _: DecimalType) => castTo(v, new DecimalType(None))
+    case (v, dt: DecimalType) => castTo(v, dt)
     case (_, dataType) =>
       sys.error(s"Failed to parse a value for data type $dataType.")
   }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -36,7 +36,7 @@ private[xml] object InferSchema {
 
   /**
    * Copied from internal Spark api
-   * [[org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion]]
+   * [[org.apache.spark.sql.catalyst.analysis.TypeCoercion]]
    */
   private val numericPrecedence: IndexedSeq[DataType] =
     IndexedSeq[DataType](
@@ -47,7 +47,7 @@ private[xml] object InferSchema {
       FloatType,
       DoubleType,
       TimestampType,
-      DecimalType.Unlimited)
+      DecimalType.SYSTEM_DEFAULT)
 
   val findTightestCommonTypeOfTwo: (DataType, DataType) => Option[DataType] = {
     case (t1, t2) if t1 == t2 => Some(t1)

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -19,7 +19,6 @@ import java.io.CharArrayWriter
 import java.nio.charset.Charset
 import javax.xml.stream.XMLOutputFactory
 
-
 import scala.collection.Map
 
 import com.databricks.spark.xml.parsers.StaxXmlGenerator

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -15,12 +15,20 @@
  */
 package com.databricks.spark.xml.util
 
+import java.io.CharArrayWriter
 import java.nio.charset.Charset
+import javax.xml.stream.XMLOutputFactory
 
+
+import scala.collection.Map
+
+import com.databricks.spark.xml.parsers.StaxXmlGenerator
+import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.io.{Text, LongWritable}
 
-import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.DataFrame
 import com.databricks.spark.xml.{XmlOptions, XmlInputFormat}
 
 private[xml] object XmlFile {
@@ -45,6 +53,92 @@ private[xml] object XmlFile {
         classOf[XmlInputFormat],
         classOf[LongWritable],
         classOf[Text]).map(pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset))
+    }
+  }
+
+  /**
+   * Note that writing a XML file from [[DataFrame]] having a field
+   * [[org.apache.spark.sql.types.ArrayType]] with its element as nested array would have
+   * an additional nested field for the element. For example, the [[DataFrame]] having
+   * a field below,
+   *
+   *   fieldA Array(Array(data1, data2))
+   *
+   * would produce a XML file below.
+   *
+   * <fieldA>
+   *     <item>data1</item>
+   * </fieldA>
+   * <fieldA>
+   *     <item>data2</item>
+   * </fieldA>
+   *
+   * Namely, roundtrip in writing and reading can end up in different schema structure.
+   */
+  def saveAsXmlFile(
+      dataFrame: DataFrame,
+      path: String,
+      parameters: Map[String, String] = Map()): Unit = {
+    val options = XmlOptions(parameters.toMap)
+    val codecClass = CompressionCodecs.getCodecClass(options.codec)
+    val startElement = s"<${options.rootTag}>"
+    val endElement = s"</${options.rootTag}>"
+    val rowSchema = dataFrame.schema
+    val indent = XmlFile.DEFAULT_INDENT
+    val rowSeparator = XmlFile.DEFAULT_ROW_SEPARATOR
+
+    val xmlRDD = dataFrame.rdd.mapPartitions { iter =>
+      val factory = XMLOutputFactory.newInstance()
+      val writer = new CharArrayWriter()
+      val xmlWriter = factory.createXMLStreamWriter(writer)
+      val indentingXmlWriter = new IndentingXMLStreamWriter(xmlWriter)
+      indentingXmlWriter.setIndentStep(indent)
+
+      new Iterator[String] {
+        var firstRow: Boolean = true
+        var lastRow: Boolean = true
+
+        override def hasNext: Boolean = iter.hasNext || firstRow || lastRow
+
+        override def next: String = {
+          if (iter.nonEmpty) {
+            val xml = {
+              StaxXmlGenerator(
+                rowSchema,
+                indentingXmlWriter,
+                options)(iter.next())
+              writer.toString
+            }
+            writer.reset()
+
+            // Here it needs to add indentations for the start of each line,
+            // in order to insert the start element and end element.
+            val indentedXml = indent + xml.replaceAll(rowSeparator, rowSeparator + indent)
+            if (firstRow) {
+              firstRow = false
+              startElement + rowSeparator + indentedXml
+            } else {
+              indentedXml
+            }
+          } else {
+            indentingXmlWriter.close()
+            if (!firstRow) {
+              lastRow = false
+              endElement
+            } else {
+              // This means the iterator was initially empty.
+              firstRow = false
+              lastRow = false
+              ""
+            }
+          }
+        }
+      }
+    }
+
+    codecClass match {
+      case null => xmlRDD.saveAsTextFile(path)
+      case codec => xmlRDD.saveAsTextFile(path, codec)
     }
   }
 }

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -49,9 +49,9 @@ public class JavaXmlSuite {
 
     @Test
     public void testXmlParser() {
-        DataFrame df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(sqlContext, booksFile);
+        Dataset df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(sqlContext, booksFile);
         String prefix = XmlOptions.DEFAULT_ATTRIBUTE_PREFIX();
-        int result = df.select(prefix + "id").collect().length;
+        long result = df.select(prefix + "id").count();
         Assert.assertEquals(result, numBooks);
     }
 
@@ -61,19 +61,19 @@ public class JavaXmlSuite {
         options.put("rowTag", booksFileTag);
         options.put("path", booksFile);
 
-        DataFrame df = sqlContext.load("com.databricks.spark.xml", options);
-        int result = df.select("description").collect().length;
+        Dataset df = sqlContext.load("com.databricks.spark.xml", options);
+        long result = df.select("description").count();
         Assert.assertEquals(result, numBooks);
     }
 
     @Test
     public void testSave() {
-        DataFrame df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(sqlContext, booksFile);
+        Dataset df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(sqlContext, booksFile);
         TestUtils.deleteRecursively(new File(tempDir));
-        df.select("price", "description").save(tempDir, "com.databricks.spark.xml");
+        df.select("price", "description").write().format("xml").save(tempDir);
 
-        DataFrame newDf = (new XmlReader()).xmlFile(sqlContext, tempDir);
-        int result = newDf.select("price").collect().length;
+        Dataset newDf = (new XmlReader()).xmlFile(sqlContext, tempDir);
+        long result = newDf.select("price").count();
         Assert.assertEquals(result, numBooks);
     }
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -377,8 +377,10 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "books-copy.xml"
 
     val books = sqlContext.xmlFile(booksComplicatedFile, rowTag = booksTag)
-    books.saveAsXmlFile(copyFilePath,
-      Map("rootTag" -> booksRootTag, "rowTag" -> booksTag))
+    books.write
+      .options(Map("rootTag" -> booksRootTag, "rowTag" -> booksTag))
+      .format("xml")
+      .save(copyFilePath)
 
     val booksCopy = sqlContext.xmlFile(copyFilePath + "/", rowTag = booksTag)
     assert(booksCopy.count == books.count)
@@ -392,8 +394,10 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "books-copy.xml"
 
     val books = sqlContext.xmlFile(booksComplicatedFile, rowTag = booksTag)
-    books.saveAsXmlFile(copyFilePath,
-      Map("rootTag" -> booksRootTag, "rowTag" -> booksTag, "nullValue" -> ""))
+    books.write
+      .options(Map("rootTag" -> booksRootTag, "rowTag" -> booksTag, "nullValue" -> ""))
+      .format("xml")
+      .save(copyFilePath)
 
     val booksCopy =
       sqlContext.xmlFile(copyFilePath, rowTag = booksTag, treatEmptyValuesAsNulls = true)
@@ -413,7 +417,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val data = sqlContext.sparkContext.parallelize(
       List(List(List("aa", "bb"), List("aa", "bb")))).map(Row(_))
     val df = sqlContext.createDataFrame(data, schema)
-    df.saveAsXmlFile(copyFilePath)
+    df.write.format("xml").save(copyFilePath)
 
     // When [[ArrayType]] has [[ArrayType]] as elements, it is confusing what is the element
     // name for XML file. Now, it is "item". So, "item" field is additionally added
@@ -458,7 +462,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val data = sqlContext.sparkContext.parallelize(Seq(row))
 
     val df = sqlContext.createDataFrame(data, schema)
-    df.saveAsXmlFile(copyFilePath)
+    df.write.format("xml").save(copyFilePath)
 
     val dfCopy = new XmlReader()
             .withSchema(schema)

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -333,8 +333,11 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "cars-copy.xml"
 
     val cars = sqlContext.xmlFile(carsFile)
-    cars.save("com.databricks.spark.xml", SaveMode.Overwrite,
-      Map("path" -> copyFilePath, "codec" -> classOf[GzipCodec].getName))
+    cars.write
+      .format("xml")
+      .mode(SaveMode.Overwrite)
+      .options(Map("path" -> copyFilePath, "codec" -> classOf[GzipCodec].getName))
+      .save(copyFilePath)
     val carsCopyPartFile = new File(copyFilePath, "part-00000.gz")
     // Check that the part file has a .gz extension
     assert(carsCopyPartFile.exists())
@@ -352,8 +355,11 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "cars-copy.xml"
 
     val cars = sqlContext.xmlFile(carsFile)
-    cars.save("com.databricks.spark.xml", SaveMode.Overwrite,
-      Map("path" -> copyFilePath, "codec" -> "gZiP"))
+    cars.write
+      .format("xml")
+      .mode(SaveMode.Overwrite)
+      .options(Map("path" -> copyFilePath, "codec" -> "gZiP"))
+      .save(copyFilePath)
     val carsCopyPartFile = new File(copyFilePath, "part-00000.gz")
     // Check that the part file has a .gz extension
     assert(carsCopyPartFile.exists())

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -783,18 +783,18 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
   test("Empty string not allowed for rowTag, attributePrefix and valueTag.") {
     val messageOne = intercept[IllegalArgumentException] {
-      sqlContext.xmlFile(carsFile, rowTag = "").collect()
+      sqlContext.read.format("xml").option("rowTag", "").load(carsFile)
     }.getMessage
     assert(messageOne == "requirement failed: 'rowTag' option should not be empty string.")
 
     val messageTwo = intercept[IllegalArgumentException] {
-      sqlContext.xmlFile(carsFile, attributePrefix = "").collect()
+      sqlContext.read.format("xml").option("attributePrefix", "").load(carsFile)
     }.getMessage
     assert(
       messageTwo == "requirement failed: 'attributePrefix' option should not be empty string.")
 
     val messageThree = intercept[IllegalArgumentException] {
-      sqlContext.xmlFile(carsFile, valueTag = "").collect()
+      sqlContext.read.format("xml").option("valueTag", "").load(carsFile)
     }.getMessage
     assert(messageThree == "requirement failed: 'valueTag' option should not be empty string.")
   }

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -28,7 +28,7 @@ class TypeCastSuite extends FunSuite {
   test("Can parse decimal type values") {
     val stringValues = Seq("10.05", "1,000.01", "158,058,049.001")
     val decimalValues = Seq(10.05, 1000.01, 158058049.001)
-    val decimalType = new DecimalType(None)
+    val decimalType = DecimalType.SYSTEM_DEFAULT
 
     stringValues.zip(decimalValues).foreach { case (strVal, decimalVal) =>
       assert(TypeCast.castTo(strVal, decimalType) === new BigDecimal(decimalVal.toString))


### PR DESCRIPTION
This PR migrates spark-xml to Spark 2.0.

This PR,
 - deprecates `saveAsXmlFile` and promote the usage of `write()`.
 - deprecates `xmlFile` and promote the usage of `read()`.
 - drops 1.x compatibility from 0.4.0.
 - makes not supporting `UserDefinedType` as it became private.