### PR TITLE
Change books to book in Hadoop InputFormat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<book>")
 sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</book>")
 sc.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, "utf-8")
 
-val records = context.newAPIHadoopFile(
+val records = sc.newAPIHadoopFile(
   path,
   classOf[XmlInputFormat],
   classOf[LongWritable],

--- a/README.md
+++ b/README.md
@@ -475,8 +475,8 @@ which you may make direct use of as follows:
 import com.databricks.spark.xml.XmlInputFormat
 
 // This will detect the tags including attributes
-sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<books>")
-sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</books>")
+sc.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, "<book>")
+sc.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, "</book>")
 sc.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, "utf-8")
 
 val records = context.newAPIHadoopFile(


### PR DESCRIPTION
The example books.xml file does not contain a `books` element. It does
contain a `catalog` element and many `book` elements. Previously,
`records.count()` would return `0`. Now, it would return `12`.