### PR TITLE
Add missed other default case when parsing/inferring XML documents

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -112,6 +112,7 @@ private[xml] object StaxXmlParser {
           case _: EndElement if data.isEmpty => null
           case _: EndElement if options.treatEmptyValuesAsNulls => null
           case _: EndElement => data
+          case _ => convertField(parser, dataType, options)
         }
 
       case (c: Characters, ArrayType(st, _)) =>

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -143,6 +143,7 @@ private[xml] object InferSchema {
           case _: EndElement if data.isEmpty => NullType
           case _: EndElement if options.treatEmptyValuesAsNulls => NullType
           case _: EndElement => StringType
+          case _ => inferField(parser, options)
         }
       case c: Characters if !c.isWhiteSpace =>
         // This means data exists

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -2,6 +2,9 @@
 <root>
 	<item>
 		<b>
+
+			<!-- nested comments -->
+
 			<es>
 				<e>1</e>
 			</es>
@@ -10,6 +13,9 @@
 	<item>
         <!-- Issue 117 - This is where an empty Row would be produced instead of null -->
 		<b>
+
+			<!-- nested comments -->
+
 			<es></es>
 		</b>
 	</item>

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -2,9 +2,7 @@
 <root>
 	<item>
 		<b>
-
 			<!-- nested comments -->
-
 			<es>
 				<e>1</e>
 			</es>

--- a/src/test/resources/simple-nested-objects.xml
+++ b/src/test/resources/simple-nested-objects.xml
@@ -1,12 +1,16 @@
 <ROWSET>
     <ROW>
         <c>
+            <!-- nested comments -->
             <a>111</a>
             <b>222</b>
         </c>
     </ROW>
     <ROW>
         <c>
+
+            <!-- nested comments -->
+
             <a>333</a>
             <b>444</b>
         </c>

--- a/src/test/resources/simple-nested-objects.xml
+++ b/src/test/resources/simple-nested-objects.xml
@@ -1,16 +1,12 @@
 <ROWSET>
     <ROW>
         <c>
-            <!-- nested comments -->
             <a>111</a>
             <b>222</b>
         </c>
     </ROW>
     <ROW>
         <c>
-
-            <!-- nested comments -->
-
             <a>333</a>
             <b>444</b>
         </c>


### PR DESCRIPTION
This PR adds the support for skipping multiple white spaces around a comment.

This should have been added but missed. As `XMLStreamConstants.COMMENT` is always skipped [here](https://github.com/databricks/spark-xml/blob/master/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala#L51-L52) and [here](https://github.com/databricks/spark-xml/blob/master/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala#L85-L86) but it seems it is possible to have the `COMMENT` is between white spaces.

In this case, `factory.setProperty(XMLInputFactory.IS_COALESCING, true)` does not coalesce both white spaces.

In more details,

```xml
<a>
  <!-- comment -->
  <b>...</b>
</a>
```

in this case, `<!--comment -->` is surrounded with whitespaces. 

This produces the events as blow:

```bash
XMLStreamConstants.CHARACTERS     # whitespace
XMLStreamConstants.COMMENT        # comment
XMLStreamConstants.CHARACTERS     # whitespace
XMLStreamConstants.START_ELEMENT  # <b>
```

Current codes always filter `XmlEvent.COMMENT` so it ends up with 

```bash
XMLStreamConstants.CHARACTERS     # whitespace
XMLStreamConstants.CHARACTERS     # whitespace
XMLStreamConstants.START_ELEMENT  # <b>
```

which does not happen in normal cases because we are coalescing multiple `XMLStreamConstants.CHARACTERS` into single one as below:

```bash
XMLStreamConstants.CHARACTERS     # whitespace
XMLStreamConstants.START_ELEMENT  # <b>
```

