### PR TITLE
Do not allow empty strings for attributePrefix, valueTag and rowTag

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -36,9 +36,9 @@ private[xml] class XmlOptions(
   val valueTag = parameters.getOrElse("valueTag", XmlOptions.DEFAULT_VALUE_TAG)
   val nullValue = parameters.getOrElse("nullValue", XmlOptions.DEFAULT_NULL_VALUE)
 
-  require(rowTag != "", "'rowTag' option should not be empty string.")
-  require(attributePrefix != "", "'attributePrefix' option should not be empty string.")
-  require(valueTag != "", "'valueTag' option should not be empty string.")
+  require(rowTag.nonEmpty, "'rowTag' option should not be empty string.")
+  require(attributePrefix.nonEmpty, "'attributePrefix' option should not be empty string.")
+  require(valueTag.nonEmpty, "'valueTag' option should not be empty string.")
 }
 
 private[xml] object XmlOptions {

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -35,6 +35,10 @@ private[xml] class XmlOptions(
     parameters.getOrElse("attributePrefix", XmlOptions.DEFAULT_ATTRIBUTE_PREFIX)
   val valueTag = parameters.getOrElse("valueTag", XmlOptions.DEFAULT_VALUE_TAG)
   val nullValue = parameters.getOrElse("nullValue", XmlOptions.DEFAULT_NULL_VALUE)
+
+  require(rowTag != "", "'rowTag' option should not be empty string.")
+  require(attributePrefix != "", "'attributePrefix' option should not be empty string.")
+  require(valueTag != "", "'valueTag' option should not be empty string.")
 }
 
 private[xml] object XmlOptions {

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -715,7 +715,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(lastActual === lastExpected)
   }
 
-  test("Nested element with same name as parent schema inferance") {
+  test("Nested element with same name as parent schema inference") {
     val df = new XmlReader()
       .withRowTag("parent")
       .xmlFile(sqlContext, nestedElementWithNameOfParent)
@@ -730,5 +730,23 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     df.schema.printTreeString()
     schema.printTreeString()
     assert(df.schema == schema)
+  }
+
+  test("Empty string not allowed for rowTag, attributePrefix and valueTag.") {
+    val messageOne = intercept[IllegalArgumentException] {
+      sqlContext.xmlFile(carsFile, rowTag = "").collect()
+    }.getMessage
+    assert(messageOne == "requirement failed: 'rowTag' option should not be empty string.")
+
+    val messageTwo = intercept[IllegalArgumentException] {
+      sqlContext.xmlFile(carsFile, attributePrefix = "").collect()
+    }.getMessage
+    assert(
+      messageTwo == "requirement failed: 'attributePrefix' option should not be empty string.")
+
+    val messageThree = intercept[IllegalArgumentException] {
+      sqlContext.xmlFile(carsFile, valueTag = "").collect()
+    }.getMessage
+    assert(messageThree == "requirement failed: 'valueTag' option should not be empty string.")
   }
 }


### PR DESCRIPTION
This PR adds requirements for `attributePrefix`, `valueTag` and `rowTag`.

Since those options are used to differentiate attributes, `attributePrefix` should not be just a empty string

`valueTag` is used for a column name so it should not be empty string.

Lastly, we should set the explicit range for each row via `rowTag`. Therefore, this should not be just empty string too.