### PR TITLE
Treat nullValue for string as well and deprecate treatEmptyAsNulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When reading files the API accepts several options:
 * `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
 * `samplingRatio`: Sampling ratio for inferring schema (0.0 ~ 1). Default is 1. Possible types are `StructType`, `ArrayType`, `StringType`, `LongType`, `DoubleType`, `BooleanType`, `TimestampType` and `NullType`, unless user provides a schema for this.
 * `excludeAttribute` : Whether you want to exclude attributes in elements or not. Default is false.
-* `treatEmptyValuesAsNulls` : Whether you want to treat whitespaces as a null value. Default is false.
+* `treatEmptyValuesAsNulls` : (DEPRECATED: use `nullValue` set to `""`) Whether you want to treat whitespaces as a null value. Default is false
 * `mode`: The mode for dealing with corrupt records during parsing. Default is `PERMISSIVE`.
   * `PERMISSIVE` : sets other fields to `null` when it meets a corrupted record, and puts the malformed string into a new field configured by `columnNameOfCorruptRecord`. When a schema is set by user, it sets `null` for extra fields.
   * `DROPMALFORMED` : ignores the whole corrupted records.

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -24,6 +24,7 @@ import scala.util.Try
 import scala.util.control.Exception._
 
 import org.apache.spark.sql.types._
+import com.databricks.spark.xml.XmlOptions
 
 /**
  * Utility functions for type casting
@@ -43,9 +44,11 @@ object TypeCast {
   private[xml] def castTo(
       datum: String,
       castType: DataType,
-      nullable: Boolean = true,
-      treatEmptyValuesAsNulls: Boolean = false): Any = {
-    if (datum == "" && nullable && (!castType.isInstanceOf[StringType] || treatEmptyValuesAsNulls)){
+      options: XmlOptions,
+      nullable: Boolean = true): Any = {
+    if (datum == options.nullValue &&
+      nullable ||
+      (options.treatEmptyValuesAsNulls && datum == "")){
       null
     } else {
       castType match {
@@ -109,55 +112,57 @@ object TypeCast {
     (allCatch opt Timestamp.valueOf(value)).isDefined
   }
 
-  private[xml] def signSafeToLong(value: String): Long = {
+  // TODO: It seems sign-safe is too much and decreases the performance. Maybe
+  // this just should be deprecated and matched to CSV and JSON datasources.
+  private[xml] def signSafeToLong(value: String, options: XmlOptions): Long = {
     if (value.startsWith("+")) {
       val data = value.substring(1)
-      TypeCast.castTo(data, LongType).asInstanceOf[Long]
+      TypeCast.castTo(data, LongType, options).asInstanceOf[Long]
     } else if (value.startsWith("-")) {
       val data = value.substring(1)
-      -TypeCast.castTo(data, LongType).asInstanceOf[Long]
+      -TypeCast.castTo(data, LongType, options).asInstanceOf[Long]
     } else {
       val data = value
-      TypeCast.castTo(data, LongType).asInstanceOf[Long]
+      TypeCast.castTo(data, LongType, options).asInstanceOf[Long]
     }
   }
 
-  private[xml] def signSafeToDouble(value: String): Double = {
+  private[xml] def signSafeToDouble(value: String, options: XmlOptions): Double = {
     if (value.startsWith("+")) {
       val data = value.substring(1)
-      TypeCast.castTo(data, DoubleType).asInstanceOf[Double]
+      TypeCast.castTo(data, DoubleType, options).asInstanceOf[Double]
     } else if (value.startsWith("-")) {
       val data = value.substring(1)
-     -TypeCast.castTo(data, DoubleType).asInstanceOf[Double]
+     -TypeCast.castTo(data, DoubleType, options).asInstanceOf[Double]
     } else {
       val data = value
-      TypeCast.castTo(data, DoubleType).asInstanceOf[Double]
+      TypeCast.castTo(data, DoubleType, options).asInstanceOf[Double]
     }
   }
 
-  private[xml] def signSafeToInt(value: String): Int = {
+  private[xml] def signSafeToInt(value: String, options: XmlOptions): Int = {
     if (value.startsWith("+")) {
       val data = value.substring(1)
-      TypeCast.castTo(data, IntegerType).asInstanceOf[Int]
+      TypeCast.castTo(data, IntegerType, options).asInstanceOf[Int]
     } else if (value.startsWith("-")) {
       val data = value.substring(1)
-      -TypeCast.castTo(data, IntegerType).asInstanceOf[Int]
+      -TypeCast.castTo(data, IntegerType, options).asInstanceOf[Int]
     } else {
       val data = value
-      TypeCast.castTo(data, IntegerType).asInstanceOf[Int]
+      TypeCast.castTo(data, IntegerType, options).asInstanceOf[Int]
     }
   }
 
-  private[xml] def signSafeToFloat(value: String): Float = {
+  private[xml] def signSafeToFloat(value: String, options: XmlOptions): Float = {
     if (value.startsWith("+")) {
       val data = value.substring(1)
-      TypeCast.castTo(data, FloatType).asInstanceOf[Float]
+      TypeCast.castTo(data, FloatType, options).asInstanceOf[Float]
     } else if (value.startsWith("-")) {
       val data = value.substring(1)
-      -TypeCast.castTo(data, FloatType).asInstanceOf[Float]
+      -TypeCast.castTo(data, FloatType, options).asInstanceOf[Float]
     } else {
       val data = value
-      TypeCast.castTo(data, FloatType).asInstanceOf[Float]
+      TypeCast.castTo(data, FloatType, options).asInstanceOf[Float]
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -776,8 +776,6 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       Seq(
         StructField("child", StringType, nullable = true),
         StructField("parent", nestedSchema, nullable = true)))
-    df.schema.printTreeString()
-    schema.printTreeString()
     assert(df.schema == schema)
   }
 
@@ -797,5 +795,19 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       sqlContext.read.format("xml").option("valueTag", "").load(carsFile)
     }.getMessage
     assert(messageThree == "requirement failed: 'valueTag' option should not be empty string.")
+  }
+
+  test("nullValue and treatEmptyValuesAsNulls test") {
+    val resultsOne = sqlContext.read.format("xml")
+      .option("treatEmptyValuesAsNulls", "true")
+      .load(gpsEmptyField)
+    assert(resultsOne.selectExpr("extensions.TrackPointExtension").head().isNullAt(0))
+    assert(resultsOne.collect().size === numGPS)
+
+    val resultsTwo = sqlContext.read.format("xml")
+      .option("nullValue", "2013-01-24T06:18:43Z")
+      .load(gpsEmptyField)
+    assert(resultsTwo.selectExpr("time").head().isNullAt(0))
+    assert(resultsTwo.collect().size === numGPS)
   }
 }

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -26,21 +26,22 @@ import com.databricks.spark.xml.XmlOptions
 
 class TypeCastSuite extends FunSuite {
 
-  val defaultOptions = new XmlOptions(Map.empty[String, String])
-
   test("Can parse decimal type values") {
+    val options = new XmlOptions(Map.empty[String, String])
+
     val stringValues = Seq("10.05", "1,000.01", "158,058,049.001")
     val decimalValues = Seq(10.05, 1000.01, 158058049.001)
     val decimalType = DecimalType.SYSTEM_DEFAULT
 
     stringValues.zip(decimalValues).foreach { case (strVal, decimalVal) =>
       val decimal = new BigDecimal(decimalVal.toString)
-      assert(TypeCast.castTo(strVal, decimalType, defaultOptions) === decimal)
+      assert(TypeCast.castTo(strVal, decimalType, options) === decimal)
     }
   }
 
   test("Nullable types are handled") {
     val options = new XmlOptions(Map("nullValue" -> "-"))
+
     assert(TypeCast.castTo("-", ByteType, options) == null)
     assert(TypeCast.castTo("-", ShortType, options) == null)
     assert(TypeCast.castTo("-", IntegerType, options) == null)
@@ -54,35 +55,42 @@ class TypeCastSuite extends FunSuite {
   }
 
   test("String type should always return the same as the input") {
-    assert(TypeCast.castTo("", StringType, defaultOptions) == "")
+    val options = new XmlOptions(Map.empty[String, String])
+
+    assert(TypeCast.castTo("", StringType, options) == "")
   }
 
   test("Throws exception for empty string with non null type") {
+    val options = new XmlOptions(Map.empty[String, String])
+
     val exception = intercept[NumberFormatException]{
-      TypeCast.castTo("", IntegerType, defaultOptions, nullable = false)
+      TypeCast.castTo("", IntegerType, options, nullable = false)
     }
     assert(exception.getMessage.contains("For input string: \"\""))
   }
 
   test("Types are cast correctly") {
-    assert(TypeCast.castTo("10", ByteType, defaultOptions) == 10)
-    assert(TypeCast.castTo("10", ShortType, defaultOptions) == 10)
-    assert(TypeCast.castTo("10", IntegerType, defaultOptions) == 10)
-    assert(TypeCast.castTo("10", LongType, defaultOptions) == 10)
-    assert(TypeCast.castTo("1.00", FloatType, defaultOptions) == 1.0)
-    assert(TypeCast.castTo("1.00", DoubleType, defaultOptions) == 1.0)
-    assert(TypeCast.castTo("true", BooleanType, defaultOptions) == true)
+    val options = new XmlOptions(Map.empty[String, String])
+
+    assert(TypeCast.castTo("10", ByteType, options) == 10)
+    assert(TypeCast.castTo("10", ShortType, options) == 10)
+    assert(TypeCast.castTo("10", IntegerType, options) == 10)
+    assert(TypeCast.castTo("10", LongType, options) == 10)
+    assert(TypeCast.castTo("1.00", FloatType, options) == 1.0)
+    assert(TypeCast.castTo("1.00", DoubleType, options) == 1.0)
+    assert(TypeCast.castTo("true", BooleanType, options) == true)
     val timestamp = "2015-01-01 00:00:00"
     assert(
-      TypeCast.castTo(timestamp, TimestampType, defaultOptions) == Timestamp.valueOf(timestamp))
-    assert(TypeCast.castTo("2015-01-01", DateType, defaultOptions) == Date.valueOf("2015-01-01"))
+      TypeCast.castTo(timestamp, TimestampType, options) == Timestamp.valueOf(timestamp))
+    assert(TypeCast.castTo("2015-01-01", DateType, options) == Date.valueOf("2015-01-01"))
   }
 
   test("Types with sign are cast correctly") {
-    assert(TypeCast.signSafeToInt("+10", defaultOptions) == 10)
-    assert(TypeCast.signSafeToLong("-10", defaultOptions) == -10)
-    assert(TypeCast.signSafeToFloat("1.00", defaultOptions) == 1.0)
-    assert(TypeCast.signSafeToDouble("-1.00", defaultOptions) == -1.0)
+    val options = new XmlOptions(Map.empty[String, String])
+    assert(TypeCast.signSafeToInt("+10", options) == 10)
+    assert(TypeCast.signSafeToLong("-10", options) == -10)
+    assert(TypeCast.signSafeToFloat("1.00", options) == 1.0)
+    assert(TypeCast.signSafeToDouble("-1.00", options) == -1.0)
   }
 
   test("Types with sign are checked correctly") {
@@ -95,9 +103,10 @@ class TypeCastSuite extends FunSuite {
   }
 
   test("Float and Double Types are cast correctly with Locale") {
+    val options = new XmlOptions(Map.empty[String, String])
     val locale : Locale = new Locale("fr", "FR")
     Locale.setDefault(locale)
-    assert(TypeCast.castTo("1,00", FloatType, defaultOptions) == 1.0)
-    assert(TypeCast.castTo("1,00", DoubleType, defaultOptions) == 1.0)
+    assert(TypeCast.castTo("1,00", FloatType, options) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType, options) == 1.0)
   }
 }


### PR DESCRIPTION
#156

This PR fixes `nullValue` handling for `StringType`. It seems it'd be better to treat all the types consistently. 

Also, this PR deprecates `treatEmptyAsNulls` as `nullValue` with `""` can be the same.

Lastly, there are two todos added to avoid unnecessary type-dispatch and the note to deprecate sign-safe conversion/inference and match to CSV and JSON datasource in Spark.
