### PR TITLE
Do not sienlty produce null but skip the children XML elements by the pushed down projection

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -305,4 +305,3 @@ private[xml] object StaxXmlParser {
     Row.fromSeq(row)
   }
 }
-

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -260,36 +260,39 @@ private[xml] object StaxXmlParser {
         case e: StartElement =>
           val nameToIndex = schema.map(_.name).zipWithIndex.toMap
           // If there are attributes, then we process them first.
-          convertAttributes(rootAttributes, schema, options).toSeq.foreach {
-            case (f, v) =>
-              nameToIndex.get(f).foreach { row(_) = v }
+          convertAttributes(rootAttributes, schema, options).toSeq.foreach { case (f, v) =>
+            nameToIndex.get(f).foreach { row(_) = v }
           }
 
           val attributes = e.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           val field = e.asStartElement.getName.getLocalPart
 
-          nameToIndex.get(field).foreach { index =>
-            schema(index).dataType match {
-              case st: StructType =>
-                row(index) = convertObjectWithAttributes(parser, st, options, attributes)
+          nameToIndex.get(field) match {
+            case Some(index) =>
+              schema(index).dataType match {
+                case st: StructType =>
+                  row(index) = convertObjectWithAttributes(parser, st, options, attributes)
 
-              case ArrayType(dt: DataType, _) =>
-                val values = Option(row(index))
-                  .map(_.asInstanceOf[ArrayBuffer[Any]])
-                  .getOrElse(ArrayBuffer.empty[Any])
-                val newValue = {
-                  dt match {
-                    case st: StructType =>
-                      convertObjectWithAttributes(parser, st, options, attributes)
-                    case dt: DataType =>
-                      convertField(parser, dt, options)
+                case ArrayType(dt: DataType, _) =>
+                  val values = Option(row(index))
+                    .map(_.asInstanceOf[ArrayBuffer[Any]])
+                    .getOrElse(ArrayBuffer.empty[Any])
+                  val newValue = {
+                    dt match {
+                      case st: StructType =>
+                        convertObjectWithAttributes(parser, st, options, attributes)
+                      case dt: DataType =>
+                        convertField(parser, dt, options)
+                    }
                   }
-                }
-                row(index) = values :+ newValue
+                  row(index) = values :+ newValue
 
-              case dt: DataType =>
-                row(index) = convertField(parser, dt, options)
-            }
+                case dt: DataType =>
+                  row(index) = convertField(parser, dt, options)
+              }
+
+            case None =>
+              StaxXmlParserUtils.skipChildren(parser)
           }
 
         case _: EndElement =>

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -111,17 +111,15 @@ private[xml] object StaxXmlParserUtils {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          parser.peek match {
-            case c: Characters if c.isWhiteSpace =>
-              // There can be a `Characters` event between `StartElement`s.
-              // So, we need to check further to decide if this is a data or just
-              // a whitespace between them.
-              parser.next
-              parser.peek match {
-                case _: StartElement => skipChildren(parser)
-                case _: XMLEvent => // In case, just skip.
-              }
-            case _: XMLEvent => // In case, just skip.
+          val e = parser.peek
+          if (e.isCharacters && e.asCharacters.isWhiteSpace) {
+            // There can be a `Characters` event between `StartElement`s.
+            // So, we need to check further to decide if this is a data or just
+            // a whitespace between them.
+            parser.next
+            if (parser.peek.isStartElement) {
+              skipChildren(parser)
+            }
           }
         case _: EndElement =>
           shouldStop = checkEndElement(parser)

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -77,6 +77,8 @@ private[xml] object StaxXmlParserUtils {
           parser.peek match {
             case _: StartElement =>
               childrenXmlString += currentStructureAsString(parser)
+            case e: XMLEvent =>
+              childrenXmlString += e.toString
           }
         case e: XMLEvent =>
           childrenXmlString += e.toString
@@ -99,5 +101,33 @@ private[xml] object StaxXmlParserUtils {
       }
     }
     xmlString
+  }
+
+  /**
+   * Skip the children of the current XML element.
+   */
+  def skipChildren(parser: XMLEventReader): Unit = {
+    var shouldStop = checkEndElement(parser)
+    while (!shouldStop) {
+      parser.nextEvent match {
+        case e: StartElement =>
+          parser.peek match {
+            case c: Characters if c.isWhiteSpace =>
+              // There can be a `Characters` event between `StartElement`s.
+              // So, we need to check further to decide if this is a data or just
+              // a whitespace between them.
+              parser.next
+              parser.peek match {
+                case _: StartElement => skipChildren(parser)
+                case _: XMLEvent => // In case, just skip.
+              }
+            case _: XMLEvent => // In case, just skip.
+          }
+        case _: EndElement =>
+          shouldStop = checkEndElement(parser)
+        case _: XMLEvent =>
+          shouldStop = shouldStop && parser.hasNext
+      }
+    }
   }
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -788,7 +788,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .selectExpr("publish_dates")
       .collect()
     results.foreach { row =>
-      // All nested fields should have four elements.
+      // All nested fields should not have nulls but arrays.
       assert(!row.anyNull)
     }
   }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -781,6 +781,18 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(df.schema == schema)
   }
 
+  test("Select correctly all child fields regardless of pushed down projection") {
+    val results = sqlContext.read.format("xml")
+      .option("rowTag", "book")
+      .load(booksComplicatedFile)
+      .selectExpr("publish_dates")
+      .collect()
+    results.foreach { row =>
+      // All nested fields should have four elements.
+      assert(!row.anyNull)
+    }
+  }
+
   test("Empty string not allowed for rowTag, attributePrefix and valueTag.") {
     val messageOne = intercept[IllegalArgumentException] {
       sqlContext.read.format("xml").option("rowTag", "").load(carsFile)

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
@@ -76,4 +76,19 @@ class StaxXmlParserUtilsSuite extends FunSuite with BeforeAndAfterAll {
       <name>Sam Mad Dog Smith</name><amount><small>1</small><large>9</large></amount></info>
     assert(xmlString === expected.toString())
   }
+
+  test("Skip XML children") {
+    val input = <ROW><id>2</id><info>
+      <name>Sam Mad Dog Smith</name><amount><small>1</small><large>9</large></amount></info></ROW>
+    val reader = new ByteArrayInputStream(input.toString().getBytes)
+    val parser = factory.createXMLEventReader(reader)
+    // We assume here it's reading the value within `id` field.
+    StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.CHARACTERS)
+    StaxXmlParserUtils.skipChildren(parser)
+    assert(
+      parser.nextEvent().asEndElement().getName.getLocalPart == "id")
+    StaxXmlParserUtils.skipChildren(parser)
+    assert(
+      parser.nextEvent().asEndElement().getName.getLocalPart == "info")
+  }
 }


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/185

This PR proposes to handle pushed down projection correctly via skipping the children XML elements.

`PrunedScan` was introduced in XML before and therefore we should be able to skip the children elements. Currently, it sometimes for parsing and skipping the elements of struct types when processing pushed down projection.