### PR TITLE
Add an option `ignoreSurroundingSpaces` to allow to trim spaces between values

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ When reading files the API accepts several options:
 * `attributePrefix`: The prefix for attributes so that we can differentiate attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
+* `ignoreSurroundingSpaces`: Defines whether or not surrounding whitespaces from values being read should be skipped. Default is false.
 
 When writing files the API accepts several options:
 * `path`: Location to write files.

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -41,6 +41,8 @@ private[xml] class XmlOptions(
   val nullValue = parameters.getOrElse("nullValue", XmlOptions.DEFAULT_NULL_VALUE)
   val columnNameOfCorruptRecord =
     parameters.getOrElse("columnNameOfCorruptRecord", "_corrupt_record")
+  val ignoreSurroundingSpaces =
+    parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
 
   // Leave this option for backwards compatibility.
   private val failFastFlag = parameters.get("failFast").map(_.toBoolean).getOrElse(false)

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -62,8 +62,8 @@ class XmlReader extends Serializable {
     this
   }
 
-  def withParseMode(valueTag: String): XmlReader = {
-    parameters += ("mode" -> valueTag)
+  def withParseMode(mode: String): XmlReader = {
+    parameters += ("mode" -> mode)
     this
   }
 
@@ -79,6 +79,11 @@ class XmlReader extends Serializable {
 
   def withColumnNameOfCorruptRecord(name: String): XmlReader = {
     parameters += ("columnNameOfCorruptRecord" -> name)
+    this
+  }
+
+  def withIgnoreSurroundingSpaces(ignore: Boolean): XmlReader = {
+    parameters += ("ignoreSurroundingSpaces" -> ignore.toString)
     this
   }
 

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -140,28 +140,6 @@ private[xml] object StaxXmlParser {
     }
   }
 
-  // TODO: This function unnecessarily does type dispatch. This should be removed
-  // as removing the support for signed numbers.
-  private def convertTo(
-      value: String,
-      dataType: DataType,
-      options: XmlOptions): Any = dataType match {
-    case NullType if value == null => null
-    case LongType => signSafeToLong(value, options)
-    case DoubleType => signSafeToDouble(value, options)
-    case BooleanType => castTo(value, BooleanType, options)
-    case StringType => castTo(value, StringType, options)
-    case DateType => castTo(value, DateType, options)
-    case TimestampType => castTo(value, TimestampType, options)
-    case FloatType => signSafeToFloat(value, options)
-    case ByteType => castTo(value, ByteType, options)
-    case ShortType => castTo(value, ShortType, options)
-    case IntegerType => signSafeToInt(value, options)
-    case dt: DecimalType => castTo(value, dt, options)
-    case _ =>
-      sys.error(s"Failed to parse a value for data type $dataType.")
-  }
-
   /**
    * Parse an object as map.
    */

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -118,7 +118,12 @@ private[xml] object InferSchema {
   }
 
   private def inferFrom(datum: String, options: XmlOptions): DataType = {
-    val value = if (options.ignoreSurroundingSpaces) datum.trim() else datum
+    val value = if (datum != null && options.ignoreSurroundingSpaces) {
+      datum.trim()
+    } else {
+      datum
+    }
+
     value match {
       case null => NullType
       case v if v.isEmpty => NullType

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -75,7 +75,12 @@ object TypeCast {
       datum: String,
       dataType: DataType,
       options: XmlOptions): Any = {
-    val value = if (options.ignoreSurroundingSpaces) datum.trim() else datum
+    val value = if (datum != null && options.ignoreSurroundingSpaces) {
+      datum.trim()
+    } else {
+      datum
+    }
+
     dataType match {
       case NullType => castTo(value, StringType, options)
       case LongType => signSafeToLong(value, options)

--- a/src/test/resources/ages-with-spaces.xml
+++ b/src/test/resources/ages-with-spaces.xml
@@ -1,0 +1,20 @@
+<people>
+  <person>
+    <age born=" 1990-02-24 "> 25 </age>
+    <name>
+
+       Hyukjin
+
+    </name>
+  </person>
+  <person>
+    <age born="
+
+    1985-01-01">   30 </age>
+    <name>Lars</name>
+  </person>
+  <person>
+    <age born=" 1980-01-01">30 </age>
+    <name> Lion </name>
+  </person>
+</people>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -36,6 +36,7 @@ import com.databricks.spark.xml.util.ParseModes
 class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val tempEmptyDir = "target/test/empty/"
   val agesFile = "src/test/resources/ages.xml"
+  val agesWithSpacesFile = "src/test/resources/ages-with-spaces.xml"
   val booksFile = "src/test/resources/books.xml"
   val booksNestedObjectFile = "src/test/resources/books-nested-object.xml"
   val booksNestedArrayFile = "src/test/resources/books-nested-array.xml"
@@ -829,5 +830,18 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .load(gpsEmptyField)
     assert(resultsTwo.selectExpr("time").head().isNullAt(0))
     assert(resultsTwo.collect().size === numGPS)
+  }
+
+  test("ignoreSurroundingSpaces test") {
+    val results = new XmlReader()
+      .withIgnoreSurroundingSpaces(true)
+      .withRowTag(agesTag)
+      .xmlFile(sqlContext, agesWithSpacesFile)
+      .collect()
+    val attrValOne = results(0).get(0).asInstanceOf[Row](1)
+    val attrValTwo = results(1).get(0).asInstanceOf[Row](0)
+    assert(attrValOne === "1990-02-24")
+    assert(attrValTwo === 30)
+    assert(results.length === numAges)
   }
 }


### PR DESCRIPTION
https://github.com/databricks/spark-xml/issues/236

It seems it is painful to treat these, especially, we provide a schema to XML file but it ended up with having some spaces. It ends up with an error such as ...

```
java.lang.NumberFormatException: For input string: "1 "
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:441)
```

It seems supporting to trim seems reasonable according to https://www.w3.org/TR/xmlschema-2/#rf-whiteSpace

