### PR TITLE
Fix for NPE and support for attributes at root level

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ When writing files the API accepts several options:
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `compression`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
+* Additionally, any options supplied which start with the given `attributePrefix` will be used as attributes on the root element. The option name is used as the attribute name (minus the prefix). E.g. to specify an `xmlns` attribute, set the option `@xmlns` to the desired value.
 
 Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When writing files the API accepts several options:
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `compression`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
-* Additionally, any options supplied which start with the given `attributePrefix` will be used as attributes on the root element. The option name is used as the attribute name (minus the prefix). E.g. to specify an `xmlns` attribute, set the option `@xmlns` to the desired value.
+* Additionally, any options supplied which start with the given `attributePrefix` will be used as attributes on the root element. The option name is used as the attribute name (minus the prefix). E.g. to specify an `xmlns` attribute, set the option `_xmlns` to the desired value.
 
 Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
 

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -61,6 +61,11 @@ private[xml] class XmlOptions(
   val dropMalformed = ParseModes.isDropMalformedMode(parseMode)
   val permissive = ParseModes.isPermissiveMode(parseMode)
 
+  val rootAttributes: Map[String, String] = parameters.collect {
+    case (k, v) if k.startsWith(attributePrefix) && k.size > attributePrefix.length =>
+      k.substring(attributePrefix.length) -> v
+  }
+
   require(rowTag.nonEmpty, "'rowTag' option should not be empty string.")
   require(attributePrefix.nonEmpty, "'attributePrefix' option should not be empty string.")
   require(valueTag.nonEmpty, "'valueTag' option should not be empty string.")

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -20,7 +20,7 @@ import scala.collection.Map
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import com.databricks.spark.xml.util.XmlFile
+import com.databricks.spark.xml.util.{XmlFile, XmlRDD}
 
 package object xml {
   /**
@@ -82,12 +82,10 @@ package object xml {
     def saveAsXmlFile(
         path: String, parameters: Map[String, String] = Map(),
         compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
-      val mutableParams = collection.mutable.Map(parameters.toSeq: _*)
-      val safeCodec = mutableParams.get("codec")
+      val codecOpt = parameters.get("codec")
         .orElse(Option(compressionCodec).map(_.getCanonicalName))
-        .orNull
-      mutableParams.put("codec", safeCodec)
-      XmlFile.saveAsXmlFile(dataFrame, path, mutableParams.toMap)
+      val paramsWithCodec = codecOpt.map(c => parameters + ("codec" -> c)).getOrElse(parameters)
+      XmlFile.saveAsXmlFile(dataFrame, path, paramsWithCodec)
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -127,6 +127,10 @@ private[xml] object StaxXmlGenerator {
     // Writing attributes
     writer.writeStartElement(options.rowTag)
     attributes.foreach {
+      case (f, v) if f.name.startsWith(options.attributePrefix) && (v == null || f.dataType == NullType) =>
+          Option(options.nullValue).foreach {
+            writer.writeAttribute(f.name.substring(options.attributePrefix.length), _)
+          }
       case (f, v) =>
         writer.writeAttribute(f.name.substring(options.attributePrefix.length), v.toString)
     }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -127,10 +127,11 @@ private[xml] object StaxXmlGenerator {
     // Writing attributes
     writer.writeStartElement(options.rowTag)
     attributes.foreach {
-      case (f, v) if f.name.startsWith(options.attributePrefix) && (v == null || f.dataType == NullType) =>
-          Option(options.nullValue).foreach {
-            writer.writeAttribute(f.name.substring(options.attributePrefix.length), _)
-          }
+      case (f, v)
+          if f.name.startsWith(options.attributePrefix) && (v == null || f.dataType == NullType) =>
+        Option(options.nullValue).foreach {
+          writer.writeAttribute(f.name.substring(options.attributePrefix.length), _)
+        }
       case (f, v) =>
         writer.writeAttribute(f.name.substring(options.attributePrefix.length), v.toString)
     }

--- a/src/main/scala/com/databricks/spark/xml/util/XmlRDD.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlRDD.scala
@@ -1,0 +1,70 @@
+package com.databricks.spark.xml.util
+
+import java.io.CharArrayWriter
+import javax.xml.stream.XMLOutputFactory
+
+import scala.collection.Map
+
+import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrame
+import com.databricks.spark.xml.parsers.StaxXmlGenerator
+import com.databricks.spark.xml.XmlOptions
+
+object XmlRDD {
+
+  def apply(dataFrame: DataFrame, parameters: Map[String, String]): RDD[String] = {
+    val options = XmlOptions(parameters.toMap)
+    val rowSchema = dataFrame.schema
+    val indent = XmlFile.DEFAULT_INDENT
+    val rowSeparator = XmlFile.DEFAULT_ROW_SEPARATOR
+
+    dataFrame.rdd.mapPartitions { iter =>
+      val factory = XMLOutputFactory.newInstance()
+      val writer = new CharArrayWriter()
+      val xmlWriter = factory.createXMLStreamWriter(writer)
+      val indentingXmlWriter = new IndentingXMLStreamWriter(xmlWriter)
+      indentingXmlWriter.setIndentStep(indent)
+
+      indentingXmlWriter.writeStartElement(options.rootTag)
+      for ((name, value) <- options.rootAttributes) {
+        indentingXmlWriter.writeAttribute(name, value)
+      }
+      val startElement = writer.toString
+      writer.reset()
+
+      new Iterator[String] {
+        var firstRow: Boolean = true
+        var lastRow: Boolean = iter.nonEmpty
+
+        override def hasNext: Boolean = iter.hasNext || lastRow
+
+        override def next: String = {
+          if (iter.nonEmpty) {
+            if (firstRow) {
+              firstRow = false
+              startElement + ">"
+            } else {
+              val xml = {
+                StaxXmlGenerator(
+                  rowSchema,
+                  indentingXmlWriter,
+                  options)(iter.next())
+                writer.toString
+              }
+              writer.reset()
+              xml.stripPrefix(">").stripPrefix(rowSeparator)
+            }
+          } else {
+            indentingXmlWriter.writeEndDocument()
+            val endElement = writer.toString
+            indentingXmlWriter.close()
+            lastRow = false
+            endElement
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -443,9 +443,10 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       List("The Winds of Winter", "George R R Martin", null, "fantasy")
     )).map(Row.fromSeq)
     val df = sqlContext.createDataFrame(data, schema)
-    df.coalesce(1).saveAsXmlFile(filePath, Map("rowTag" -> booksTag, "rootTag" -> booksRootTag, "nullValue" -> null,
-      "attributePrefix" -> "_"))
-    val xml = Files.readAllLines(Paths.get(filePath + "/part-00000"), Charset.defaultCharset()).asScala.mkString("\n")
+    df.coalesce(1).saveAsXmlFile(filePath, Map("rowTag" -> booksTag, "rootTag" -> booksRootTag,
+      "nullValue" -> null, "attributePrefix" -> "_"))
+    val xml = Files.readAllLines(Paths.get(filePath + "/part-00000"),
+      Charset.defaultCharset()).asScala.mkString("\n")
     assert(xml === """<books>
       |    <book publishDate="1997">
       |        <title>Harry Potter and the Philosopher's Stone</title>
@@ -475,10 +476,11 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       List("Paradise Lost", Row("John Milton", "Sagittarius"))
     )).map(Row.fromSeq)
     val df = sqlContext.createDataFrame(data, schema)
-    df.coalesce(1).saveAsXmlFile(filePath, Map("rowTag" -> booksTag, "rootTag" -> booksRootTag, "nullValue" -> null,
-      "attributePrefix" -> "_", "_xmlns" -> "http://example.com/books", "_xmlns:a" -> "http://example.com/authors",
-      "valueTag" -> "VALUE"))
-    val xml = Files.readAllLines(Paths.get(filePath + "/part-00000"), Charset.defaultCharset()).asScala.mkString("\n")
+    df.coalesce(1).saveAsXmlFile(filePath, Map("rowTag" -> booksTag, "rootTag" -> booksRootTag,
+      "nullValue" -> null, "attributePrefix" -> "_", "_xmlns" -> "http://example.com/books",
+      "_xmlns:a" -> "http://example.com/authors", "valueTag" -> "VALUE"))
+    val xml = Files.readAllLines(Paths.get(filePath + "/part-00000"),
+      Charset.defaultCharset()).asScala.mkString("\n")
     assert(xml === """<books xmlns="http://example.com/books" xmlns:a="http://example.com/authors">
       |    <book>
       |        <title>Harry Potter and the Philosopher's Stone</title>

--- a/src/test/scala/com/databricks/spark/xml/util/XmlRDDSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XmlRDDSuite.scala
@@ -1,0 +1,63 @@
+package com.databricks.spark.xml.util
+
+import org.scalatest.{FunSuite, BeforeAndAfterAll}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{SQLContext, Row}
+import org.apache.spark.sql.types.{StructType, StructField, StringType}
+
+class XmlRDDSuite extends FunSuite with BeforeAndAfterAll {
+
+  private var sqlContext: SQLContext = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    sqlContext = new SQLContext(new SparkContext("local[2]", "XmlRDDSuite"))
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sqlContext.sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("empty dataframe is converted to an empty xml rdd") {
+    // Check that a dataframe where all partitions are empty is converted
+    // to an empty RDD (i.e. doesn't add opening and closing root tags)
+    val rows: RDD[Row] = sqlContext.sparkContext.parallelize(Seq[Row]())
+    val df = sqlContext.createDataFrame(rows, StructType(Array(StructField("ROW", StringType))))
+    val xmlRdd = XmlRDD(df, Map())
+    xmlRdd.collect().foreach(println)
+    assert(xmlRdd.isEmpty)
+  }
+
+  test("RDD contains a string for each row of the dataframe plus opening and closing root tags") {
+    val rows = sqlContext.sparkContext.parallelize(Seq(
+      Seq("The Cat in the Hat", "Dr Suess"),
+      Seq("Where the Wild Things Are", "Maurice Sendak")
+    ).map(Row.fromSeq))
+    val df = sqlContext.createDataFrame(rows, StructType(Array(
+      StructField("title", StringType),
+      StructField("author", StringType)
+    )))
+    val xmlRdd = XmlRDD(df, Map("rootTag" -> "books", "rowTag" -> "book"))
+    assert(xmlRdd.partitions.size === 2)
+    val partitionArrays = xmlRdd.glom().collect()
+
+    assert(partitionArrays.head === Array("<books>",
+      """    <book>
+        |        <title>The Cat in the Hat</title>
+        |        <author>Dr Suess</author>
+        |    </book>""".stripMargin,
+        "</books>"))
+    assert(partitionArrays(1) === Array("<books>",
+      """    <book>
+        |        <title>Where the Wild Things Are</title>
+        |        <author>Maurice Sendak</author>
+        |    </book>""".stripMargin,
+        "</books>"))
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/xml/util/XmlRDDSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XmlRDDSuite.scala
@@ -29,8 +29,7 @@ class XmlRDDSuite extends FunSuite with BeforeAndAfterAll {
     val rows: RDD[Row] = sqlContext.sparkContext.parallelize(Seq[Row]())
     val df = sqlContext.createDataFrame(rows, StructType(Array(StructField("ROW", StringType))))
     val xmlRdd = XmlRDD(df, Map())
-    xmlRdd.collect().foreach(println)
-    assert(xmlRdd.isEmpty)
+    assert(xmlRdd.collect().isEmpty)
   }
 
   test("RDD contains a string for each row of the dataframe plus opening and closing root tags") {


### PR DESCRIPTION
- Fixes a NullPointerException when writing null attribute values at row level
- Adds support for adding attributes to the root element. The main use case for this is adding `xmlns` attributes; this is implemented by means of adding options that start with the attribute prefix.
- Extracts the functionality for creating an RDD[String] from a dataframe into its own object. My motivation for this change was a data import format that requires a `<Summary>` element at the start of the XML document, but it also allows for arbitrary manipulation of the data as strings. I haven't documented this in the readme as this is a fairly advanced use case - happy to add a bit in if you think it's appropriate.