### PR TITLE
Add shortcuts for read.format("xml").load() and write.format("xml").save()

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,49 +182,68 @@ OPTIONS (path "books.xml", rowTag "book")
 
 ```scala
 import org.apache.spark.sql.SQLContext
+import com.databricks.spark.xml._
 
 val sqlContext = new SQLContext(sc)
 val df = sqlContext.read
-    .format("com.databricks.spark.xml")
-    .option("rowTag", "book")
-    .load("books.xml")
+  .option("rowTag", "book")
+  .xml("books.xml")
 
 val selectedData = df.select("author", "_id")
 selectedData.write
-    .format("com.databricks.spark.xml")
-    .option("rootTag", "books")
-    .option("rowTag", "book")
-    .save("newbooks.xml")
+  .option("rootTag", "books")
+  .option("rowTag", "book")
+  .xml("newbooks.xml")
+```
+
+Alternatively you can specify the format to use instead:
+
+```scala
+import org.apache.spark.sql.SQLContext
+
+val sqlContext = new SQLContext(sc)
+val df = sqlContext.read
+  .format("com.databricks.spark.xml")
+  .option("rowTag", "book")
+  .load("books.xml")
+
+val selectedData = df.select("author", "_id")
+selectedData.write
+  .format("com.databricks.spark.xml")
+  .option("rootTag", "books")
+  .option("rowTag", "book")
+  .save("newbooks.xml")
 ```
 
 You can manually specify the schema when reading data:
+
 ```scala
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.types.{StructType, StructField, StringType, DoubleType};
 
 val sqlContext = new SQLContext(sc)
 val customSchema = StructType(Array(
-    StructField("_id", StringType, nullable = true),
-    StructField("author", StringType, nullable = true),
-    StructField("description", StringType, nullable = true),
-    StructField("genre", StringType ,nullable = true),
-    StructField("price", DoubleType, nullable = true),
-    StructField("publish_date", StringType, nullable = true),
-    StructField("title", StringType, nullable = true)))
+  StructField("_id", StringType, nullable = true),
+  StructField("author", StringType, nullable = true),
+  StructField("description", StringType, nullable = true),
+  StructField("genre", StringType ,nullable = true),
+  StructField("price", DoubleType, nullable = true),
+  StructField("publish_date", StringType, nullable = true),
+  StructField("title", StringType, nullable = true)))
 
 
 val df = sqlContext.read
-    .format("com.databricks.spark.xml")
-    .option("rowTag", "book")
-    .schema(customSchema)
-    .load("books.xml")
+  .format("com.databricks.spark.xml")
+  .option("rowTag", "book")
+  .schema(customSchema)
+  .load("books.xml")
 
 val selectedData = df.select("author", "_id")
 selectedData.write
-    .format("com.databricks.spark.xml")
-    .option("rootTag", "books")
-    .option("rowTag", "book")
-    .save("newbooks.xml")
+  .format("com.databricks.spark.xml")
+  .option("rootTag", "books")
+  .option("rowTag", "book")
+  .save("newbooks.xml")
 ```
 
 ### Java API
@@ -234,15 +253,15 @@ import org.apache.spark.sql.SQLContext
 
 SQLContext sqlContext = new SQLContext(sc);
 DataFrame df = sqlContext.read()
-    .format("com.databricks.spark.xml")
-    .option("rowTag", "book")
-    .load("books.xml");
+  .format("com.databricks.spark.xml")
+  .option("rowTag", "book")
+  .load("books.xml");
 
 df.select("author", "_id").write()
-    .format("com.databricks.spark.xml")
-    .option("rootTag", "books")
-    .option("rowTag", "book")
-    .save("newbooks.xml");
+  .format("com.databricks.spark.xml")
+  .option("rootTag", "books")
+  .option("rowTag", "book")
+  .save("newbooks.xml");
 ```
 
 You can manually specify schema:
@@ -252,30 +271,29 @@ import org.apache.spark.sql.types.*;
 
 SQLContext sqlContext = new SQLContext(sc);
 StructType customSchema = new StructType(new StructField[] {
-    new StructField("_id", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("author", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("description", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("genre", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("price", DataTypes.DoubleType, true, Metadata.empty()),
-    new StructField("publish_date", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("title", DataTypes.StringType, true, Metadata.empty())
+  new StructField("_id", DataTypes.StringType, true, Metadata.empty()),
+  new StructField("author", DataTypes.StringType, true, Metadata.empty()),
+  new StructField("description", DataTypes.StringType, true, Metadata.empty()),
+  new StructField("genre", DataTypes.StringType, true, Metadata.empty()),
+  new StructField("price", DataTypes.DoubleType, true, Metadata.empty()),
+  new StructField("publish_date", DataTypes.StringType, true, Metadata.empty()),
+  new StructField("title", DataTypes.StringType, true, Metadata.empty())
 });
 
 DataFrame df = sqlContext.read()
-    .format("com.databricks.spark.xml")
-    .option("rowTag", "book")
-    .schema(customSchema)
-    .load("books.xml");
+  .format("com.databricks.spark.xml")
+  .option("rowTag", "book")
+  .schema(customSchema)
+  .load("books.xml");
 
 df.select("author", "_id").write()
-    .format("com.databricks.spark.xml")
-    .option("rootTag", "books")
-    .option("rowTag", "book")
-    .save("newbooks.xml");
+  .format("com.databricks.spark.xml")
+  .option("rootTag", "books")
+  .option("rowTag", "book")
+  .save("newbooks.xml");
 ```
 
 ### Python API
-
 
 ```python
 from pyspark.sql import SQLContext

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -96,9 +96,9 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test with xml having unbalanced datatypes") {
-    val results = sqlContext.read.format("xml")
+    val results = sqlContext.read
       .option("treatEmptyValuesAsNulls", "true")
-      .load(gpsEmptyField)
+      .xml(gpsEmptyField)
 
     assert(results.collect().size === numGPS)
   }
@@ -468,7 +468,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val data = sqlContext.sparkContext.parallelize(
       List(List(List("aa", "bb"), List("aa", "bb")))).map(Row(_))
     val df = sqlContext.createDataFrame(data, schema)
-    df.write.format("xml").save(copyFilePath)
+    df.write.xml(copyFilePath)
 
     // When [[ArrayType]] has [[ArrayType]] as elements, it is confusing what is the element
     // name for XML file. Now, it is "item". So, "item" field is additionally added


### PR DESCRIPTION
This PR proposes Scala-specific short-cuts for `read.format("xml").load()` and `write.format("xml").save()` as below:


```scala
df.read.xml(path)
```

```scala
df.write.xml(path)
```