### PR TITLE
[Fix] Malformed attributes cause ClassCastException in XML Parser

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -22,6 +22,7 @@ import javax.xml.stream._
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
+import scala.util.control.NonFatal
 
 import org.slf4j.LoggerFactory
 
@@ -84,11 +85,7 @@ private[xml] object StaxXmlParser {
           Some(convertObject(parser, schema, options, rootAttributes))
             .orElse(failedRecord(xml))
         } catch {
-          case _: java.lang.NumberFormatException =>
-            failedRecord(xml)
-          case _: java.text.ParseException | _: IllegalArgumentException =>
-            failedRecord(xml)
-          case _: XMLStreamException =>
+          case NonFatal(_) =>
             failedRecord(xml)
         }
       }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -16,20 +16,21 @@
 package com.databricks.spark.xml.util
 
 import java.io.ByteArrayInputStream
-import javax.xml.stream.events._
 import javax.xml.stream._
+import javax.xml.stream.events._
 
-import com.databricks.spark.xml.parsers.StaxXmlParserUtils
-import org.slf4j.LoggerFactory
-
+import scala.collection.JavaConversions._
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.JavaConversions._
+import scala.util.control.NonFatal
 
+import org.slf4j.LoggerFactory
+
+import com.databricks.spark.xml.XmlOptions
+import com.databricks.spark.xml.parsers.StaxXmlParserUtils
+import com.databricks.spark.xml.util.TypeCast._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
-import com.databricks.spark.xml.util.TypeCast._
-import com.databricks.spark.xml.XmlOptions
 
 private[xml] object InferSchema {
   private val logger = LoggerFactory.getLogger(InferSchema.getClass)
@@ -100,9 +101,9 @@ private[xml] object InferSchema {
 
           Some(inferObject(parser, options, rootAttributes))
         } catch {
-          case _: XMLStreamException if shouldHandleCorruptRecord =>
+          case NonFatal(_) if shouldHandleCorruptRecord =>
             Some(StructType(Seq(StructField(options.columnNameOfCorruptRecord, StringType))))
-          case _: XMLStreamException =>
+          case NonFatal(_) =>
             None
         }
       }

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -16,8 +16,11 @@
 package com.databricks.spark.xml;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 
+import org.apache.spark.SparkConf;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,7 +28,6 @@ import org.junit.Test;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
-import com.databricks.spark.xml.XmlOptions;
 
 public class JavaXmlSuite {
     private transient SQLContext sqlContext;
@@ -37,8 +39,12 @@ public class JavaXmlSuite {
     private String tempDir = "target/test/xmlData/";
 
     @Before
-    public void setUp() {
-        sqlContext = new SQLContext(new SparkContext("local[2]", "JavaXmlSuite"));
+    public void setUp() throws IOException {
+        // Fix Spark 2.0.0 on windows, see https://issues.apache.org/jira/browse/SPARK-15893
+        SparkConf conf = new SparkConf().set(
+                "spark.sql.warehouse.dir",
+                Files.createTempDirectory("spark-warehouse").toString());
+        sqlContext = new SQLContext(new SparkContext("local[2]", "JavaXmlSuite", conf));
     }
 
     @After

--- a/src/test/resources/books-malformed-attributes.xml
+++ b/src/test/resources/books-malformed-attributes.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="Malformed attribute with " caracter ">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems
+      of being quantum.</description>
+   </book>
+   <book id='I'm malformed too!'>
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in
+      detail, with attention to XML DOM interfaces, XSLT processing,
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are
+      integrated into a comprehensive development
+      environment.</description>
+   </book>
+</catalog>


### PR DESCRIPTION
# Context
This PR fixes the issue related to malformed attributes in XML documents.

# Fix
## Schema
The schema inferring will not stop on a malformed attribute
An empty Schema will be returned if the parsing mode is not permissive
## Parsing
Documents with invalid attributes will be treated or dropped based on parsing mode