### PR TITLE
Output valid streaming XML with woodstox

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -101,6 +101,10 @@ private[xml] object XmlFile {
 
         override def next: String = {
           if (iter.nonEmpty) {
+            if (firstRow) {
+              indentingXmlWriter.writeStartElement(options.rootTag)
+              firstRow = false
+            }
             val xml = {
               StaxXmlGenerator(
                 rowSchema,
@@ -109,21 +113,13 @@ private[xml] object XmlFile {
               writer.toString
             }
             writer.reset()
-
-            // Here it needs to add indentations for the start of each line,
-            // in order to insert the start element and end element.
-            val indentedXml = indent + xml.replaceAll(rowSeparator, rowSeparator + indent)
-            if (firstRow) {
-              firstRow = false
-              startElement + rowSeparator + indentedXml
-            } else {
-              indentedXml
-            }
+            xml
           } else {
-            indentingXmlWriter.close()
             if (!firstRow) {
               lastRow = false
-              endElement
+              indentingXmlWriter.writeEndElement()
+              indentingXmlWriter.close()
+              writer.toString
             } else {
               // This means the iterator was initially empty.
               firstRow = false


### PR DESCRIPTION
Hadoop added a woodstox dependency in https://issues.apache.org/jira/browse/HADOOP-14501. When using versions of Hadoop with that dependency, WstxOutputFactory will get loaded for XMLOutputFactory.newInstance. The resulting streamwriter will ensure that a client does not write two root elements, which causes the current code to error out.

This PR makes it such that the writer function will start the root tag before writing rows. 