### PR TITLE
Fix parsing xml with unicode characters in row tag name

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlInputFormat.scala
@@ -164,7 +164,7 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
         // End of file or end of split.
         return false
       } else {
-        if (b == startTag(i)) {
+        if (b.toByte == startTag(i)) {
           if (i >= startTag.length - 1) {
             // Found start tag.
             return true
@@ -192,12 +192,13 @@ private[xml] class XmlRecordReader extends RecordReader[LongWritable, Text] {
     var ei = 0
     var depth = 0
     while (true) {
-      val b = in.read()
-      if (b == -1) {
+      val rb = in.read()
+      if (rb == -1) {
         // End of file (ignore end of split).
         return false
       } else {
-        buffer.write(b)
+        buffer.write(rb)
+        val b = rb.toByte
         if (b == startTag(si) && b == endTag(ei)) {
           // In start tag or end tag.
           si += 1

--- a/src/test/resources/books-unicode-in-tag-name.xml
+++ b/src/test/resources/books-unicode-in-tag-name.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<κατάλογος>
+    <書 ид="bk101">
+        <aŭtoro>Gambardella, Matthew</aŭtoro>
+        <ítulo>XML Developer's Guide</ítulo>
+        <ჟანრი>Computer</ჟანრი>
+        <цена>44.95</цена>
+        <publish_date>2000-10-01</publish_date>
+    </書>
+    <書>
+        <aŭtoro>Ralls, Kim</aŭtoro>
+        <ítulo>Midnight Rain</ítulo>
+        <ჟანრი>Fantasy</ჟანრი>
+        <цена>5.95</цена>
+        <publish_date>2000-12-16</publish_date>
+    </書>
+    <書 ид="bk103">
+        <aŭtoro>Corets, Eva</aŭtoro>
+        <ítulo>Maeve Ascendant</ítulo>
+        <ჟანრი>Fantasy</ჟანრი>
+        <цена>5.95</цена>
+        <publish_date>2000-11-17</publish_date>
+    </書>
+</κατάλογος>

--- a/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
@@ -22,9 +22,13 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 class XmlFileSuite extends FunSuite with BeforeAndAfterAll {
   val booksFile = "src/test/resources/books.xml"
+  val booksUnicodeInTagNameFile = "src/test/resources/books-unicode-in-tag-name.xml"
+
   val booksFileTag = "book"
+  val booksUnicodeFileTag = "\u66F8" // scalastyle:ignore
 
   val numBooks = 12
+  val numBooksUnicodeInTagName = 3
 
   val utf8 = "utf-8"
 
@@ -46,6 +50,12 @@ class XmlFileSuite extends FunSuite with BeforeAndAfterAll {
   test("read utf-8 encoded file") {
     val baseRDD = XmlFile.withCharset(sparkContext, booksFile, utf8, rowTag = booksFileTag)
     assert(baseRDD.count() === numBooks)
+  }
+
+  test("read file with unicode chars in row tag name") {
+    val baseRDD = XmlFile.withCharset(
+      sparkContext, booksUnicodeInTagNameFile, utf8, rowTag = booksUnicodeFileTag)
+    assert(baseRDD.count() === numBooksUnicodeInTagName)
   }
 
   test("unsupported charset") {


### PR DESCRIPTION
Currently, only supported english letters in «rowTag» option.
But non-English letters and unicode characters are perfectly legal in XML element names
https://www.w3.org/TR/xml/#charsets

This PR adds the support for non-english letters and unicode characters in tag names passed as «rowTag» param in options