### PR TITLE
Add timestampFormat and dateFormat parsing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ When reading files the API accepts several options:
   * `DROPMALFORMED` : ignores the whole corrupted records.
   * `FAILFAST` : throws an exception when it meets corrupted records.
 * `columnNameOfCorruptRecord`: The name of new field where malformed strings are stored. Default is `_corrupt_record`.
+* `timestampFormat`: A string representing the timestamp format within your XML, as specified by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) specs. Default is `yyyy-MM-dd HH:mm:ss.S`.
+* `dateFormat`: A string representing the date format within your XML, as specified by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) specs. Default is `yyyy-MM-dd`.
 * `attributePrefix`: The prefix for attributes so that we can differentiate attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -15,8 +15,9 @@
  */
 package com.databricks.spark.xml
 
-import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
 
+import org.slf4j.LoggerFactory
 import com.databricks.spark.xml.util.ParseModes
 
 /**
@@ -43,6 +44,10 @@ private[xml] class XmlOptions(
     parameters.getOrElse("columnNameOfCorruptRecord", "_corrupt_record")
   val ignoreSurroundingSpaces =
     parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
+  val timestampFormat = parameters.getOrElse("timestampFormat", XmlOptions.DEFAULT_TIMESTAMP_FORMAT)
+  val timestampFormatter: SimpleDateFormat = new SimpleDateFormat(timestampFormat)
+  val dateFormat = parameters.getOrElse("dateFormat", XmlOptions.DEFAULT_DATE_FORMAT)
+  val dateFormatter: SimpleDateFormat = new SimpleDateFormat(dateFormat)
 
   // Leave this option for backwards compatibility.
   private val failFastFlag = parameters.get("failFast").map(_.toBoolean).getOrElse(false)
@@ -75,6 +80,9 @@ private[xml] object XmlOptions {
   val DEFAULT_ROOT_TAG = "ROWS"
   val DEFAULT_CHARSET = "UTF-8"
   val DEFAULT_NULL_VALUE = null
+  val DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.S"
+  val DEFAULT_DATE_FORMAT = "yyyy-MM-dd"
+
 
   def apply(parameters: Map[String, String]): XmlOptions = new XmlOptions(parameters)
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -77,6 +77,7 @@ private[xml] object StaxXmlGenerator {
       case (_, null) | (NullType, _) => writer.writeCharacters(options.nullValue)
       case (StringType, v: String) => writer.writeCharacters(v.toString)
       case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(v.toString)
+      case (DateType, v: java.sql.Date) => writer.writeCharacters(v.toString)
       case (IntegerType, v: Int) => writer.writeCharacters(v.toString)
       case (ShortType, v: Short) => writer.writeCharacters(v.toString)
       case (FloatType, v: Float) => writer.writeCharacters(v.toString)
@@ -85,7 +86,6 @@ private[xml] object StaxXmlGenerator {
       case (DecimalType(), v: java.math.BigDecimal) => writer.writeCharacters(v.toString)
       case (ByteType, v: Byte) => writer.writeCharacters(v.toString)
       case (BooleanType, v: Boolean) => writer.writeCharacters(v.toString)
-      case (DateType, v) => writer.writeCharacters(v.toString)
 
       // For the case roundtrip in reading and writing XML files, [[ArrayType]] cannot have
       // [[ArrayType]] as element type. It always wraps the element with [[StructType]]. So,

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -48,6 +48,7 @@ private[xml] object InferSchema {
       FloatType,
       DoubleType,
       TimestampType,
+      DateType,
       DecimalType.SYSTEM_DEFAULT)
 
   val findTightestCommonTypeOfTwo: (DataType, DataType) => Option[DataType] = {
@@ -132,10 +133,12 @@ private[xml] object InferSchema {
       case v if isInteger(v) => IntegerType
       case v if isDouble(v) => DoubleType
       case v if isBoolean(v) => BooleanType
-      case v if isTimestamp(v) => TimestampType
+      case v if isTimestamp(v, options.timestampFormatter) => TimestampType
+      case v if isDate(v, options.dateFormatter) => DateType
       case v => StringType
     }
   }
+
 
   private def inferField(parser: XMLEventReader, options: XmlOptions): DataType = {
     parser.peek match {

--- a/src/test/resources/dates.xml
+++ b/src/test/resources/dates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <date>2017-05-15</date>
+        <date2>2017/05/15</date2>
+    </ROW>
+    <ROW>
+        <date>2018-12-11</date>
+        <date2>2018/12/11</date2>
+    </ROW>
+    <ROW>
+        <date>1999-01-11</date>
+        <date2>1999/01/11</date2>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/invalid-times.xml
+++ b/src/test/resources/invalid-times.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <name>a</name>
+    </ROW>
+    <ROW>
+        <time>2018-12-11T10:50:11Z</time>
+        <name></name>
+    </ROW>
+    <ROW>
+        <time>N/A</time>
+        <name>c</name>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/times-and-dates.xml
+++ b/src/test/resources/times-and-dates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <date>2017-05-15</date>
+        <time2>2017-05-15 14:58:19.000</time2>
+        <date2>2017/05/15</date2>
+    </ROW>
+    <ROW>
+        <time>2018/12/11T10:50:11Z</time>
+        <date>2018-12-11</date>
+        <time2>2018-12-11 10:50:11.000</time2>
+        <date2>2018/12/11</date2>
+    </ROW>
+    <ROW>
+        <time>1999/01/11T01:01:01Z</time>
+        <date>1999-01-11</date>
+        <time2>1999-01-11 01:01:01.000</time2>
+        <date2>1999/01/11</date2>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/times.xml
+++ b/src/test/resources/times.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <time2>2017-05-15 14:58:19.000</time2>
+    </ROW>
+    <ROW>
+        <time>2018/12/11T10:50:11Z</time>
+        <time2>2018-12-11 10:50:11.000</time2>
+    </ROW>
+    <ROW>
+        <time>1999/01/11T01:01:01Z</time>
+        <time2>1999-01-11 01:01:01.000</time2>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -79,7 +79,7 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1.00", FloatType, options) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType, options) == 1.0)
     assert(TypeCast.castTo("true", BooleanType, options) == true)
-    val timestamp = "2015-01-01 00:00:00"
+    val timestamp = "2015-01-01 00:00:00.0"
     assert(
       TypeCast.castTo(timestamp, TimestampType, options) == Timestamp.valueOf(timestamp))
     assert(TypeCast.castTo("2015-01-01", DateType, options) == Date.valueOf("2015-01-01"))


### PR DESCRIPTION
User can now supply timestamp and date format options when parsing raw XML. (This addresses issue #165 open since Aug 2016)