### PR TITLE
Increase nulling granularity to preserve valid data

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ When reading files the API accepts several options:
 * `excludeAttribute` : Whether you want to exclude attributes in elements or not. Default is false.
 * `treatEmptyValuesAsNulls` : (DEPRECATED: use `nullValue` set to `""`) Whether you want to treat whitespaces as a null value. Default is false
 * `mode`: The mode for dealing with corrupt records during parsing. Default is `PERMISSIVE`.
-  * `PERMISSIVE` : sets other fields to `null` when it meets a corrupted record, and puts the malformed string into a new field configured by `columnNameOfCorruptRecord`. When a schema is set by user, it sets `null` for extra fields.
+  * `PERMISSIVE` :
+    * When it encounters a corrupted record, it sets all fields to `null` and puts the malformed string into a new field configured by `columnNameOfCorruptRecord`.
+    * When it encounters a field of the wrong datatype, it sets the offending field to `null`.
   * `DROPMALFORMED` : ignores the whole corrupted records.
   * `FAILFAST` : throws an exception when it meets corrupted records.
 * `columnNameOfCorruptRecord`: The name of new field where malformed strings are stored. Default is `_corrupt_record`.

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -80,22 +80,33 @@ object TypeCast {
     } else {
       datum
     }
-
-    dataType match {
-      case NullType => castTo(value, StringType, options)
-      case LongType => signSafeToLong(value, options)
-      case DoubleType => signSafeToDouble(value, options)
-      case BooleanType => castTo(value, BooleanType, options)
-      case StringType => castTo(value, StringType, options)
-      case DateType => castTo(value, DateType, options)
-      case TimestampType => castTo(value, TimestampType, options)
-      case FloatType => signSafeToFloat(value, options)
-      case ByteType => castTo(value, ByteType, options)
-      case ShortType => castTo(value, ShortType, options)
-      case IntegerType => signSafeToInt(value, options)
-      case dt: DecimalType => castTo(value, dt, options)
-      case _ =>
-        sys.error(s"Failed to parse a value for data type $dataType.")
+    try {
+      dataType match {
+        case NullType => castTo(value, StringType, options)
+        case LongType => signSafeToLong(value, options)
+        case DoubleType => signSafeToDouble(value, options)
+        case BooleanType => castTo(value, BooleanType, options)
+        case StringType => castTo(value, StringType, options)
+        case DateType => castTo(value, DateType, options)
+        case TimestampType => castTo(value, TimestampType, options)
+        case FloatType => signSafeToFloat(value, options)
+        case ByteType => castTo(value, ByteType, options)
+        case ShortType => castTo(value, ShortType, options)
+        case IntegerType => signSafeToInt(value, options)
+        case dt: DecimalType => castTo(value, dt, options)
+        case _ =>
+          sys.error(s"Failed to parse a value for data type $dataType.")
+      }
+    }
+    catch {
+      case e: Exception => {
+        if (options.permissive) {
+          null
+        }
+        else {
+          throw e
+        }
+      }
     }
   }
 

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -22,9 +22,10 @@ import java.util.Locale
 
 import scala.util.Try
 import scala.util.control.Exception._
-
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions
+
+import scala.util.control.NonFatal
 
 /**
  * Utility functions for type casting
@@ -99,14 +100,7 @@ object TypeCast {
       }
     }
     catch {
-      case e: Exception => {
-        if (options.permissive) {
-          null
-        }
-        else {
-          throw e
-        }
-      }
+      case NonFatal(_) if options.permissive => null
     }
   }
 

--- a/src/test/resources/datatypes-valid-and-invalid.xml
+++ b/src/test/resources/datatypes-valid-and-invalid.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <integer_value int="10">10</integer_value>
+        <long_value int="Ten">10</long_value>
+        <float_value>10.0</float_value>
+        <double_value>10.0</double_value>
+        <boolean_value>true</boolean_value>
+        <string_value>Ten</string_value>
+        <integer_array>1</integer_array>
+        <integer_array>2</integer_array>
+    </ROW>
+    <ROW>
+        <integer_value int="Ten">Ten</integer_value>
+        <long_value int="10">Ten</long_value>
+        <float_value>Ten</float_value>
+        <double_value>Ten</double_value>
+        <boolean_value>Ten</boolean_value>
+        <string_value>Ten</string_value>
+        <integer_array>Ten</integer_array>
+        <integer_array>2</integer_array>
+    </ROW>
+</ROWSET>


### PR DESCRIPTION
Encountering field parsing errors with a user-supplied schema no longer nullifies all columns in a row; instead, it only nulls out the field that failed to parse (Addresses issue #235 open since Feb 2017)
