### PR TITLE
Add timestampFormat and dateFormat parsing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ When reading files the API accepts several options:
   * `DROPMALFORMED` : ignores the whole corrupted records.
   * `FAILFAST` : throws an exception when it meets corrupted records.
 * `columnNameOfCorruptRecord`: The name of new field where malformed strings are stored. Default is `_corrupt_record`.
+* `timestampFormat`: A string representing the timestamp format within your XML, as specified by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) specs. Default is `yyyy-MM-dd HH:mm:ss.S`.
+* `dateFormat`: A string representing the date format within your XML, as specified by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) specs. Default is `yyyy-MM-dd`.
 * `attributePrefix`: The prefix for attributes so that we can differentiate attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -15,8 +15,9 @@
  */
 package com.databricks.spark.xml
 
-import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
 
+import org.slf4j.LoggerFactory
 import com.databricks.spark.xml.util.ParseModes
 
 /**
@@ -43,6 +44,10 @@ private[xml] class XmlOptions(
     parameters.getOrElse("columnNameOfCorruptRecord", "_corrupt_record")
   val ignoreSurroundingSpaces =
     parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
+  val timestampFormat = parameters.getOrElse("timestampFormat", XmlOptions.DEFAULT_TIMESTAMP_FORMAT)
+  val timestampFormatter: SimpleDateFormat = new SimpleDateFormat(timestampFormat)
+  val dateFormat = parameters.getOrElse("dateFormat", XmlOptions.DEFAULT_DATE_FORMAT)
+  val dateFormatter: SimpleDateFormat = new SimpleDateFormat(dateFormat)
 
   // Leave this option for backwards compatibility.
   private val failFastFlag = parameters.get("failFast").map(_.toBoolean).getOrElse(false)
@@ -57,13 +62,12 @@ private[xml] class XmlOptions(
     logger.warn(s"$parseMode is not a valid parse mode. Using ${ParseModes.DEFAULT}.")
   }
 
-  require(attributePrefix.nonEmpty, "'attributePrefix' option should not be empty string.")
-
   val failFast = ParseModes.isFailFastMode(parseMode)
   val dropMalformed = ParseModes.isDropMalformedMode(parseMode)
   val permissive = ParseModes.isPermissiveMode(parseMode)
 
   require(rowTag.nonEmpty, "'rowTag' option should not be empty string.")
+  require(attributePrefix.nonEmpty, "'attributePrefix' option should not be empty string.")
   require(valueTag.nonEmpty, "'valueTag' option should not be empty string.")
   require(valueTag != attributePrefix,
     "'valueTag' and 'attributePrefix' options should not be the same.")
@@ -76,6 +80,9 @@ private[xml] object XmlOptions {
   val DEFAULT_ROOT_TAG = "ROWS"
   val DEFAULT_CHARSET = "UTF-8"
   val DEFAULT_NULL_VALUE = null
+  val DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS"
+  val DEFAULT_DATE_FORMAT = "yyyy-MM-dd"
+
 
   def apply(parameters: Map[String, String]): XmlOptions = new XmlOptions(parameters)
 }

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -18,6 +18,7 @@ package com.databricks.spark.xml
 import java.text.SimpleDateFormat
 
 import org.slf4j.LoggerFactory
+
 import com.databricks.spark.xml.util.ParseModes
 
 /**

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -77,6 +77,7 @@ private[xml] object StaxXmlGenerator {
       case (_, null) | (NullType, _) => writer.writeCharacters(options.nullValue)
       case (StringType, v: String) => writer.writeCharacters(v.toString)
       case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(v.toString)
+      case (DateType, v: java.sql.Date) => writer.writeCharacters(v.toString)
       case (IntegerType, v: Int) => writer.writeCharacters(v.toString)
       case (ShortType, v: Short) => writer.writeCharacters(v.toString)
       case (FloatType, v: Float) => writer.writeCharacters(v.toString)
@@ -85,7 +86,6 @@ private[xml] object StaxXmlGenerator {
       case (DecimalType(), v: java.math.BigDecimal) => writer.writeCharacters(v.toString)
       case (ByteType, v: Byte) => writer.writeCharacters(v.toString)
       case (BooleanType, v: Boolean) => writer.writeCharacters(v.toString)
-      case (DateType, v) => writer.writeCharacters(v.toString)
 
       // For the case roundtrip in reading and writing XML files, [[ArrayType]] cannot have
       // [[ArrayType]] as element type. It always wraps the element with [[StructType]]. So,

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -172,18 +172,17 @@ private[xml] object InferSchema {
       rootAttributes: Array[Attribute] = Array.empty): DataType = {
     val builder = Seq.newBuilder[StructField]
     val nameToDataType = collection.mutable.Map.empty[String, ArrayBuffer[DataType]]
+    // If there are attributes, then we should process them first.
+    val rootValuesMap =
+      StaxXmlParserUtils.convertAttributesToValuesMap(rootAttributes, options)
+    rootValuesMap.foreach {
+      case (f, v) =>
+        nameToDataType += (f -> ArrayBuffer(inferFrom(v, options)))
+    }
     var shouldStop = false
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          // If there are attributes, then we should process them first.
-          val rootValuesMap =
-            StaxXmlParserUtils.convertAttributesToValuesMap(rootAttributes, options)
-          rootValuesMap.foreach {
-            case (f, v) =>
-              nameToDataType += (f -> ArrayBuffer(inferFrom(v, options)))
-          }
-
           val attributes = e.getAttributes.map(_.asInstanceOf[Attribute]).toArray
           val valuesMap = StaxXmlParserUtils.convertAttributesToValuesMap(attributes, options)
           val inferredType = inferField(parser, options) match {
@@ -224,7 +223,7 @@ private[xml] object InferSchema {
     }
     // We need to manually merges the fields having the sames so that
     // This can be inferred as ArrayType.
-    nameToDataType.foreach{
+    nameToDataType.foreach {
       case (field, dataTypes) if dataTypes.length > 1 =>
         val elementType = dataTypes.reduceLeft(InferSchema.compatibleType(options))
         builder += StructField(field, ArrayType(elementType), nullable = true)

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -17,7 +17,7 @@ package com.databricks.spark.xml.util
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
-import java.text.NumberFormat
+import java.text.{NumberFormat, SimpleDateFormat}
 import java.util.Locale
 
 import scala.util.Try
@@ -62,7 +62,9 @@ object TypeCast {
           .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
         case _: BooleanType => datum.toBoolean
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
-        case _: TimestampType => Timestamp.valueOf(datum)
+        case _: TimestampType => new Timestamp(options.timestampFormatter.parse(datum).getTime)
+        case _: DateType if options.dateFormatter != null =>
+          new Date(options.dateFormatter.parse(datum).getTime)
         case _: DateType => Date.valueOf(datum)
         case _: StringType => datum
         case _ => throw new RuntimeException(s"Unsupported type: ${castType.typeName}")
@@ -87,8 +89,8 @@ object TypeCast {
       case DoubleType => signSafeToDouble(value, options)
       case BooleanType => castTo(value, BooleanType, options)
       case StringType => castTo(value, StringType, options)
-      case DateType => castTo(value, DateType, options)
       case TimestampType => castTo(value, TimestampType, options)
+      case DateType => castTo(value, DateType, options)
       case FloatType => signSafeToFloat(value, options)
       case ByteType => castTo(value, ByteType, options)
       case ShortType => castTo(value, ShortType, options)
@@ -108,6 +110,17 @@ object TypeCast {
       case "true" | "false" => true
       case _ => false
     }
+  }
+
+  private[xml] def isDate(value: String, dateFormatter: SimpleDateFormat = null) = {
+    (allCatch opt(
+      if (dateFormatter == null) {
+        Date.valueOf(value)
+      }
+      else {
+        new Date(dateFormatter.parse(value).getTime)
+      }
+      )).isDefined
   }
 
   private[xml] def isDouble(value: String): Boolean = {
@@ -137,8 +150,15 @@ object TypeCast {
     (allCatch opt signSafeValue.toLong).isDefined
   }
 
-  private[xml] def isTimestamp(value: String): Boolean = {
-    (allCatch opt Timestamp.valueOf(value)).isDefined
+  private[xml] def isTimestamp(value: String, timestampFormatter: SimpleDateFormat = null) = {
+    (allCatch opt(
+      if (timestampFormatter == null) {
+        Timestamp.valueOf(value)
+      }
+      else {
+        new Timestamp(timestampFormatter.parse(value).getTime)
+      }
+      )).isDefined
   }
 
   private[xml] def signSafeToLong(value: String, options: XmlOptions): Long = {

--- a/src/test/resources/dates.xml
+++ b/src/test/resources/dates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <date>2017-05-15</date>
+        <date2>2017/05/15</date2>
+    </ROW>
+    <ROW>
+        <date>2018-12-11</date>
+        <date2>2018/12/11</date2>
+    </ROW>
+    <ROW>
+        <date>1999-01-11</date>
+        <date2>1999/01/11</date2>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/invalid-times.xml
+++ b/src/test/resources/invalid-times.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <name>a</name>
+    </ROW>
+    <ROW>
+        <time>2018-12-11T10:50:11Z</time>
+        <name></name>
+    </ROW>
+    <ROW>
+        <time>N/A</time>
+        <name>c</name>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/times-and-dates.xml
+++ b/src/test/resources/times-and-dates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <date>2017-05-15</date>
+        <time2>2017-05-15 14:58:19.000</time2>
+        <date2>2017/05/15</date2>
+    </ROW>
+    <ROW>
+        <time>2018/12/11T10:50:11Z</time>
+        <date>2018-12-11</date>
+        <time2>2018-12-11 10:50:11.000</time2>
+        <date2>2018/12/11</date2>
+    </ROW>
+    <ROW>
+        <time>1999/01/11T01:01:01Z</time>
+        <date>1999-01-11</date>
+        <time2>1999-01-11 01:01:01.000</time2>
+        <date2>1999/01/11</date2>
+    </ROW>
+</ROWSET>

--- a/src/test/resources/times.xml
+++ b/src/test/resources/times.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <time>2017/05/15T14:58:19Z</time>
+        <time2>2017-05-15 14:58:19.000</time2>
+    </ROW>
+    <ROW>
+        <time>2018/12/11T10:50:11Z</time>
+        <time2>2018-12-11 10:50:11.000</time2>
+    </ROW>
+    <ROW>
+        <time>1999/01/11T01:01:01Z</time>
+        <time2>1999-01-11 01:01:01.000</time2>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -60,6 +60,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val simpleNestedObjects = "src/test/resources/simple-nested-objects.xml"
   val nestedElementWithNameOfParent = "src/test/resources/nested-element-with-name-of-parent.xml"
   val booksMalformedAttributes = "src/test/resources/books-malformed-attributes.xml"
+  val fiasHouse = "src/test/resources/fias_house.xml"
   val timesFile = "src/test/resources/times.xml"
   val invalidTimesFile = "src/test/resources/invalid-times.xml"
   val datesFile = "src/test/resources/dates.xml"
@@ -69,6 +70,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val booksRootTag = "books"
   val topicsTag = "Topic"
   val agesTag = "person"
+  val fiasRowTag = "House"
 
   val numAges = 3
   val numCars = 3
@@ -76,6 +78,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val numBooksComplicated = 3
   val numTopics = 1
   val numGPS = 2
+  val numFiasHouses = 37
   val numTimestamps = 3
 
   val d1 = "2017/05/15"
@@ -1014,5 +1017,15 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(results.length === 2)
     assert(results(0)(0) === "bk111")
     assert(results(1)(0) === "bk112")
+  }
+
+  test("read utf-8 encoded file with empty tag") {
+    val df = sqlContext.read.format("xml")
+      .option("excludeAttribute", "false")
+      .option("rowTag", fiasRowTag)
+      .xml(fiasHouse)
+
+    assert(df.collect().length == numFiasHouses)
+    assert(df.select().where("_HOUSEID is null").count() == 0)
   }
 }

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -20,7 +20,6 @@ import java.sql.{Date, Timestamp}
 import java.util.Locale
 
 import org.scalatest.FunSuite
-
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions
 
@@ -79,9 +78,8 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1.00", FloatType, options) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType, options) == 1.0)
     assert(TypeCast.castTo("true", BooleanType, options) == true)
-    val timestamp = "2015-01-01 00:00:00"
-    assert(
-      TypeCast.castTo(timestamp, TimestampType, options) == Timestamp.valueOf(timestamp))
+    val timestamp = "2015-01-01 00:00:00.000"
+    assert(TypeCast.castTo(timestamp, TimestampType, options) == Timestamp.valueOf(timestamp))
     assert(TypeCast.castTo("2015-01-01", DateType, options) == Date.valueOf("2015-01-01"))
   }
 

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -20,6 +20,7 @@ import java.sql.{Date, Timestamp}
 import java.util.Locale
 
 import org.scalatest.FunSuite
+
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions
 


### PR DESCRIPTION
Fix issues discussed by @HyukjinKwon in #293. 
Tests for using a default timestamp of yyyy-MM-dd'T'HH:mm:ss.SSSXXX aren't consistent with timezone awareness in java.sql.timestamp