### PR TITLE
Add test case for self-closing tag inside row

### DIFF
--- a/src/test/resources/self-closing-tag.xml
+++ b/src/test/resources/self-closing-tag.xml
@@ -1,0 +1,6 @@
+<ROWSET>
+    <ROW>
+        <non-empty-tag>1</non-empty-tag>
+        <self-closing-tag/>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -61,6 +61,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val nestedElementWithNameOfParent = "src/test/resources/nested-element-with-name-of-parent.xml"
   val booksMalformedAttributes = "src/test/resources/books-malformed-attributes.xml"
   val fiasHouse = "src/test/resources/fias_house.xml"
+  val selfClosingTag = "src/test/resources/self-closing-tag.xml"
 
   val booksTag = "book"
   val booksRootTag = "books"
@@ -916,5 +917,19 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     assert(df.collect().length == numFiasHouses)
     assert(df.select().where("_HOUSEID is null").count() == 0)
+  }
+
+  test("Produces correct result for a row with a self closing tag inside") {
+    val schema = StructType(Seq(
+      StructField("non-empty-tag", IntegerType, nullable = true),
+      StructField("self-closing-tag", IntegerType, nullable = true)
+    ))
+
+    val result = new XmlReader()
+      .withSchema(schema)
+      .xmlFile(sqlContext, selfClosingTag)
+      .collect()
+
+    assert(result(0).toSeq === Seq(1, null))
   }
 }


### PR DESCRIPTION
The [latest commit](https://github.com/databricks/spark-xml/commit/f3772b296d77a5a92ae4e714f3f8cb9940f1f0f9) to master branch introduced a small bug - rows with self-closing tags inside cannot be parsed anymore.

XmlInputFormat stops reading the row once it encounters '/>' sequence. It was meant to be one of the possible endings of row, but it may happen inside it as well.

This PR doesn't solve the problem, but makes it easy to spot by providing a simple test case.
Previous master's HEAD (prior the commit in question) passes the test, so maybe the best approach would be to revert f3772 commit, apply this PR and merge f3772 back once it passes updated test suite.  