### PR TITLE
[FIX] Returns an empty Row() when a node element is empty

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -218,7 +218,11 @@ private[xml] object StaxXmlParser {
     // Return null rather than empty row. For nested structs empty row causes
     // ArrayOutOfBounds exceptions when executing an action.
     if (valuesMap.isEmpty) {
-      null
+      if (options.treatEmptyValuesAsNulls) {
+        null
+      } else {
+        Row(null)
+      }
     } else {
       Row.fromSeq(row)
     }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -763,7 +763,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .select("b.es")
       .collect()
 
-    assert(result(1).toSeq === Seq(null))
+    assert(result(1) === Row(Row(null)))
   }
 
   test("Produces correct order of columns for nested rows when user specifies a schema") {


### PR DESCRIPTION
Fix for #314 .

In the XML below the node element `<es></es>` exists and is empty in the first item while does not exist in the second. In both cases the parser returns `null`.
This behaviour does not allow to distinguish when an optional node element exists but it is empty and when it is does not exist.

The patch preserves the behaviour of option `treatEmptyValuesAsNulls` by returning `null` if set to true.

```xml
<?xml version="1.0" ?>
<root>
	<item>
		<b>
			<!-- this one returns null -->
			<es></es>
                         <c>a value</c>
		</b>
	</item>
	<item>
		<b>
			<!-- this one returns also null for  <es></es> -->
                         <c>a value</c>
		</b>
	</item>
</root>
```
