### PR TITLE
Returns an empty Row instead of null when a node has no children

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -221,7 +221,7 @@ private[xml] object StaxXmlParser {
       if (options.treatEmptyValuesAsNulls) {
         null
       } else {
-        Row(null)
+        Row.fromSeq(Seq.fill(schema.fieldNames.length)(null))
       }
     } else {
       Row.fromSeq(row)

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -108,7 +108,16 @@ private[xml] object StaxXmlParser {
 
     (parser.peek, dataType) match {
       case (_: StartElement, dt: DataType) => convertComplicatedType(dt)
-      case (_: EndElement, _: DataType) => null
+      case (_: EndElement, dt: DataType) =>
+        if (dt.isInstanceOf[StringType]) {
+          if (options.treatEmptyValuesAsNulls){
+            null
+          } else {
+            ""
+          }
+        } else {
+          null
+        }
       case (c: Characters, dt: DataType) if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide
         // if this is really data or space between other elements.

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -215,14 +215,9 @@ private[xml] object StaxXmlParser {
       nameToIndex.get(f).foreach { row(_) = v }
     }
 
-    // Return null rather than empty row. For nested structs empty row causes
-    // ArrayOutOfBounds exceptions when executing an action.
     if (valuesMap.isEmpty) {
-      if (options.treatEmptyValuesAsNulls) {
-        null
-      } else {
-        Row.fromSeq(Seq.fill(schema.fieldNames.length)(null))
-      }
+      // Return an empty row with all nested elements by the schema set to null.
+      Row.fromSeq(Seq.fill(schema.fieldNames.length)(null))
     } else {
       Row.fromSeq(row)
     }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -218,7 +218,11 @@ private[xml] object StaxXmlParser {
     // Return null rather than empty row. For nested structs empty row causes
     // ArrayOutOfBounds exceptions when executing an action.
     if (valuesMap.isEmpty) {
-      null
+      if (options.treatEmptyValuesAsNulls) {
+        null
+      } else {
+        Row(null)
+      }
     } else {
       Row.fromSeq(row)
     }

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -1,20 +1,39 @@
 <?xml version="1.0" ?>
 <root>
 	<item>
+		<!-- Issue 314 - We expect [null]
+			The node exists but is empty
+		-->
 		<b>
-			<!-- nested comments -->
+		</b>
+	</item>
+	<item>
+		<b>
+			<!-- Issue 314 - We expect [[null,null]]
+				The <es> node exists and can have two nested elements, both null
+			-->
+			<es></es>
+		</b>
+	</item>
+	<item>
+		<b>
 			<es>
-				<e>1</e>
+				<!-- Issue 314 - We expect [[E,null]]
+					The <es> node exists and can have two nested elements, E and null
+				-->
+				<e>E</e>
 			</es>
 		</b>
 	</item>
 	<item>
-        <!-- Issue 117 - This is where an empty Row would be produced instead of null -->
 		<b>
-
-			<!-- nested comments -->
-
-			<es></es>
+			<es>
+				<!-- Issue 314 - We expect [[E,null]]
+					The <es> node exists and can have two nested elements, E and F
+				-->
+				<e>E</e>
+				<f> </f>
+			</es>
 		</b>
 	</item>
 </root>

--- a/src/test/resources/null-nested-struct.xml
+++ b/src/test/resources/null-nested-struct.xml
@@ -28,11 +28,22 @@
 	<item>
 		<b>
 			<es>
-				<!-- Issue 314 - We expect [[E,null]]
-					The <es> node exists and can have two nested elements, E and F
+				<!-- Issue 314 - We expect [[E, ]]
+					The <es> node exists and can have two nested elements, E and " "
 				-->
 				<e>E</e>
 				<f> </f>
+			</es>
+		</b>
+	</item>
+	<item>
+		<b>
+			<es>
+				<!-- Issue 314 - We expect [[E,]]
+					The <es> node exists and can have two nested elements, E and ""
+				-->
+				<e>E</e>
+				<f></f>
 			</es>
 		</b>
 	</item>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -763,7 +763,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .select("b.es")
       .collect()
 
-    assert(result(1).toSeq === Seq(null))
+    assert(result(1) === Row(Row(null)))
   }
 
   test("Produces correct order of columns for nested rows when user specifies a schema") {

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -757,13 +757,23 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Missing nested struct represented as null instead of empty Row") {
+    val customSchema = new StructType()
+      .add("b",
+        new StructType()
+          .add("es", new StructType()
+            .add("e", StringType)
+            .add("f", StringType)
+          )
+        )
+
     val result = sqlContext.read.format("xml")
       .option("rowTag", "item")
+      .schema(customSchema)
       .load(nullNestedStructFile)
       .select("b.es")
       .collect()
 
-    assert(result(1) === Row(Row(null)))
+    assert(result(1) === Row(Row(null,null)))
   }
 
   test("Produces correct order of columns for nested rows when user specifies a schema") {

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -780,6 +780,32 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(result(1) === Row(Row(Row(null,null))))
     assert(result(2) === Row(Row(Row("E",null))))
     assert(result(3) === Row(Row(Row("E"," "))))
+    assert(result(4) === Row(Row(Row("E",""))))
+  }
+
+  test("Missing nested struct represented as empty Row - withTreatEmptyValuesAsNulls(true)") {
+    val leavesSchema = StructType(
+      Seq(
+        StructField("e", StringType, nullable = true),
+        StructField("f", StringType, nullable = true)))
+
+    val nestedSchema = StructType(
+      Seq(
+        StructField("es", leavesSchema, nullable = true)))
+
+    val schema = StructType(
+      Seq(
+        StructField("b", nestedSchema, nullable = true)))
+
+    val result = new XmlReader()
+        .withSchema(schema)
+        .withRowTag("item")
+        .withTreatEmptyValuesAsNulls(true)
+        .xmlFile(sqlContext, nullNestedStructFile)
+        .collect()
+
+    assert(result(3) === Row(Row(Row("E",null))))
+    assert(result(4) === Row(Row(Row("E",null))))
   }
 
   test("Produces correct order of columns for nested rows when user specifies a schema") {


### PR DESCRIPTION
See #314 for details

- Returns an empty Row instead of null when a node element has no children
- Returns an empty string instead of null when the node element has no next
