### PR TITLE
Fix minor issues to enable Scala 2.12, Spark 2.4 supports. Update plugins too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: scala
 sudo: false
+jdk: openjdk8
 cache:
   directories:
     - $HOME/.ivy2
 matrix:
   include:
-    # Spark 2.0.0
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.6.0" TEST_SPARK_VERSION="2.0.0"
+    - scala: 2.11.12
+      env: TEST_SPARK_VERSION="2.2.2"
+    - scala: 2.11.12
+      env: TEST_SPARK_VERSION="2.3.2"
+    - scala: 2.12.8
+      env: TEST_SPARK_VERSION="2.4.0"
 script:
-  - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION assembly
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
-  #- sbt ++$TRAVIS_SCALA_VERSION mima-report-binary-issues
+  #- sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -10,41 +10,42 @@ The structure and test tools are mostly copied from [CSV Data Source for Spark](
 
 ## Requirements
 
-This library requires Spark 2.0+ for 0.4.x.
+This library requires Spark 2.2+ for 0.5.x.
 
-For version that works with Spark 1.x, please check for [branch-0.3](https://github.com/databricks/spark-xml/tree/branch-0.3).
-
+For Spark 2.0.x 2.1.x, use version 0.4.x.
+For a version that works with Spark 1.x, please check for [branch-0.3](https://github.com/databricks/spark-xml/tree/branch-0.3).
 
 ## Linking
 You can link against this library in your program at the following coordinates:
-
-### Scala 2.10
-
-```
-groupId: com.databricks
-artifactId: spark-xml_2.10
-version: 0.4.1
-```
 
 ### Scala 2.11
 
 ```
 groupId: com.databricks
 artifactId: spark-xml_2.11
-version: 0.4.1
+version: 0.5.0
+```
+
+### Scala 2.12
+
+```
+groupId: com.databricks
+artifactId: spark-xml_2.12
+version: 0.5.0
 ```
 
 ## Using with Spark shell
 This package can be added to  Spark using the `--packages` command line option.  For example, to include it when starting the spark shell:
 
-### Spark compiled with Scala 2.10
-```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.10:0.4.1
-```
 
 ### Spark compiled with Scala 2.11
 ```
-$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.4.1
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.11:0.5.0
+```
+
+### Spark compiled with Scala 2.12
+```
+$SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.12:0.5.0
 ```
 
 ## Features
@@ -74,7 +75,7 @@ When writing files the API accepts several options:
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `compression`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 
-Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml` from Spark 1.5.0+
+Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml`.
 
 ## Structure Conversion
 
@@ -389,7 +390,7 @@ val records = sc.newAPIHadoopFile(
 ```
 
 ## Building From Source
-This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.10 and 2.11.
+This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script. To build a JAR file simply run `sbt/sbt package` from the project root. The build configuration includes support for both Scala 2.11 and 2.12.
 
 ## Acknowledgements
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-xml"
 
-version := "0.4.2"
+version := "0.5.0"
 
 organization := "com.databricks"
 
@@ -15,12 +15,9 @@ sparkVersion := sys.props.get("spark.testVersion").getOrElse("2.4.0")
 sparkComponents := Seq("core", "sql")
 
 libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "org.slf4j" % "slf4j-api" % "1.7.25" % "provided",
   "org.scalatest" %% "scalatest" % "3.0.3" % "test",
-  "com.novocode" % "junit-interface" % "0.9" % "test"
-)
-
-libraryDependencies ++= Seq(
+  "com.novocode" % "junit-interface" % "0.11" % "test",
   "org.apache.spark" %% "spark-core" % sparkVersion.value % "test",
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
   "org.scala-lang" % "scala-library" % scalaVersion.value % "compile"
@@ -36,7 +33,7 @@ spAppendScalaVersion := true
 
 spIncludeMaven := true
 
-pomExtra := (
+pomExtra :=
   <url>https://github.com/databricks/spark-xml</url>
   <licenses>
     <license>
@@ -55,7 +52,7 @@ pomExtra := (
       <name>Hyukjin Kwon</name>
       <url>https://www.facebook.com/hyukjin.kwon.96</url>
     </developer>
-  </developers>)
+  </developers>
 
 parallelExecution in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,34 +4,25 @@ version := "0.4.2"
 
 organization := "com.databricks"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.12"
 
 spName := "databricks/spark-xml"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.11.12", "2.12.8")
 
-sparkVersion := "2.0.0"
-
-val testSparkVersion = settingKey[String]("The version of Spark to test against.")
-
-testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
-
-val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
-
-testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+sparkVersion := sys.props.get("spark.testVersion").getOrElse("2.4.0")
 
 sparkComponents := Seq("core", "sql")
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.3" % "test",
   "com.novocode" % "junit-interface" % "0.9" % "test"
 )
 
 libraryDependencies ++= Seq(
-  "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test",
-  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force() exclude("org.apache.hadoop", "hadoop-client"),
-  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" force() exclude("org.apache.hadoop", "hadoop-client"),
+  "org.apache.spark" %% "spark-core" % sparkVersion.value % "test",
+  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
   "org.scala-lang" % "scala-library" % scalaVersion.value % "compile"
 )
 
@@ -70,8 +61,3 @@ parallelExecution in Test := false
 
 // Skip tests during assembly
 test in assembly := {}
-
-ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
-  if (scalaBinaryVersion.value == "2.10") false
-  else true
-}

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.9
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,23 +1,23 @@
 resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.2")
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" excludeAll(
   ExclusionRule(organization = "com.danieltrinh")))
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"
+libraryDependencies += "org.scalariform" %% "scalariform" % "0.2.6"
 
 addSbtPlugin("com.alpinenow" % "junit_xml_listener" % "0.5.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -35,7 +35,7 @@ import com.databricks.spark.xml.XmlOptions
 /**
  * Wraps parser to iteration process.
  */
-private[xml] object StaxXmlParser {
+private[xml] object StaxXmlParser extends Serializable {
   private val logger = LoggerFactory.getLogger(StaxXmlParser.getClass)
 
   def parse(

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -207,26 +207,23 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   test("DDL test") {
     sqlContext.sql(
       s"""
-         |CREATE TEMPORARY TABLE carsTable
+         |CREATE TEMPORARY TABLE carsTable1
          |USING com.databricks.spark.xml
          |OPTIONS (path "$carsFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT year FROM carsTable").collect().size === numCars)
+    assert(sqlContext.sql("SELECT year FROM carsTable1").collect().size === numCars)
   }
 
   test("DDL test with alias name") {
-    assume(org.apache.spark.SPARK_VERSION.take(3) >= "1.5",
-      "Datasource alias feature was added in Spark 1.5")
-
     sqlContext.sql(
       s"""
-         |CREATE TEMPORARY TABLE carsTable
+         |CREATE TEMPORARY TABLE carsTable2
          |USING xml
          |OPTIONS (path "$carsFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT year FROM carsTable").collect().size === numCars)
+    assert(sqlContext.sql("SELECT year FROM carsTable2").collect().size === numCars)
   }
 
   test("DSL test for parsing a malformed XML file") {
@@ -308,13 +305,13 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
   test("DDL test with empty file") {
     sqlContext.sql(s"""
-           |CREATE TEMPORARY TABLE carsTable
+           |CREATE TEMPORARY TABLE carsTable3
            |(year double, make string, model string, comments string, grp string)
            |USING com.databricks.spark.xml
            |OPTIONS (path "$emptyFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT count(*) FROM carsTable").collect().head(0) === 0)
+    assert(sqlContext.sql("SELECT count(*) FROM carsTable3").collect().head(0) === 0)
   }
 
   test("SQL test insert overwrite") {


### PR DESCRIPTION
CC @HyukjinKwon -- this might be a good prelude to further fixes and a new release. This should make sure Java 8, Spark 2.4 and Scala 2.12 work. Along the way I suggest we forget about Spark before 2.2. I updated plugins to match Spark for good measure.