### PR TITLE
Don't output XMLEvent.toString; doesn't work on for instance the woodstox parser

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -73,16 +73,18 @@ private[xml] object StaxXmlParserUtils {
           // There can be a `Characters` event between `StartElement`s.
           // So, we need to check further to decide if this is a data or just
           // a whitespace between them.
-          childrenXmlString += c.toString
+          childrenXmlString += c.getData
           parser.next
           parser.peek match {
             case _: StartElement =>
               childrenXmlString += currentStructureAsString(parser)
-            case e: XMLEvent =>
-              childrenXmlString += e.toString
+            case _: XMLEvent =>
+              // do nothing
           }
-        case e: XMLEvent =>
-          childrenXmlString += e.toString
+        case c: Characters =>
+          childrenXmlString += c.getData
+        case _: XMLEvent =>
+          // do nothing
       }
       childrenXmlString
     }
@@ -92,10 +94,10 @@ private[xml] object StaxXmlParserUtils {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          xmlString += e.toString
+          xmlString += "<" + e.getName + ">"
           xmlString += convertChildren()
         case e: EndElement =>
-          xmlString += e.toString
+          xmlString += "</" + e.getName + ">"
           shouldStop = checkEndElement(parser)
         case e: XMLEvent =>
           shouldStop = shouldStop && parser.hasNext


### PR DESCRIPTION
Don't output XMLEvent.toString; doesn't work on for instance the woodstox parser, which renders `[STaX event #1]` etc. Only output tag events and use the tag name directly, and output Characters elements directly instead.