### PR TITLE
Use SparkSession in favor of deprecated SQLContext in tests (deprecation warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,14 @@ You can manually specify the schema when reading data:
 
 ```scala
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.types.{StructType, StructField, StringType, DoubleType};
+import org.apache.spark.sql.types.{StructType, StructField, StringType, DoubleType}
 
 val sqlContext = new SQLContext(sc)
 val customSchema = StructType(Array(
   StructField("_id", StringType, nullable = true),
   StructField("author", StringType, nullable = true),
   StructField("description", StringType, nullable = true),
-  StructField("genre", StringType ,nullable = true),
+  StructField("genre", StringType, nullable = true),
   StructField("price", DoubleType, nullable = true),
   StructField("publish_date", StringType, nullable = true),
   StructField("title", StringType, nullable = true)))
@@ -250,7 +250,7 @@ selectedData.write
 ### Java API
 
 ```java
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SQLContext;
 
 SQLContext sqlContext = new SQLContext(sc);
 DataFrame df = sqlContext.read()

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ OPTIONS (path "books.xml", rowTag "book")
 ### Scala API
 
 ```scala
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import com.databricks.spark.xml._
 
-val sqlContext = new SQLContext(sc)
-val df = sqlContext.read
+val spark = SparkSession.builder.getOrCreate()
+val df = spark.read
   .option("rowTag", "book")
   .xml("books.xml")
 
@@ -200,10 +200,10 @@ selectedData.write
 Alternatively you can specify the format to use instead:
 
 ```scala
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
-val sqlContext = new SQLContext(sc)
-val df = sqlContext.read
+val spark = SparkSession.builder.getOrCreate()
+val df = spark.read
   .format("com.databricks.spark.xml")
   .option("rowTag", "book")
   .load("books.xml")
@@ -219,10 +219,10 @@ selectedData.write
 You can manually specify the schema when reading data:
 
 ```scala
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{StructType, StructField, StringType, DoubleType}
 
-val sqlContext = new SQLContext(sc)
+val spark = SparkSession.builder.getOrCreate()
 val customSchema = StructType(Array(
   StructField("_id", StringType, nullable = true),
   StructField("author", StringType, nullable = true),
@@ -233,7 +233,7 @@ val customSchema = StructType(Array(
   StructField("title", StringType, nullable = true)))
 
 
-val df = sqlContext.read
+val df = spark.read
   .format("com.databricks.spark.xml")
   .option("rowTag", "book")
   .schema(customSchema)
@@ -250,10 +250,10 @@ selectedData.write
 ### Java API
 
 ```java
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 
-SQLContext sqlContext = new SQLContext(sc);
-DataFrame df = sqlContext.read()
+SparkSession spark = SparkSession.builder().getOrCreate();
+DataFrame df = spark.read()
   .format("com.databricks.spark.xml")
   .option("rowTag", "book")
   .load("books.xml");
@@ -267,10 +267,10 @@ df.select("author", "_id").write()
 
 You can manually specify schema:
 ```java
-import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.*;
 
-SQLContext sqlContext = new SQLContext(sc);
+SparkSession spark = SparkSession.builder().getOrCreate();
 StructType customSchema = new StructType(new StructField[] {
   new StructField("_id", DataTypes.StringType, true, Metadata.empty()),
   new StructField("author", DataTypes.StringType, true, Metadata.empty()),
@@ -281,7 +281,7 @@ StructType customSchema = new StructType(new StructField[] {
   new StructField("title", DataTypes.StringType, true, Metadata.empty())
 });
 
-DataFrame df = sqlContext.read()
+DataFrame df = spark.read()
   .format("com.databricks.spark.xml")
   .option("rowTag", "book")
   .schema(customSchema)
@@ -297,10 +297,10 @@ df.select("author", "_id").write()
 ### Python API
 
 ```python
-from pyspark.sql import SQLContext
-sqlContext = SQLContext(sc)
+from pyspark.sql import SparkSession
+spark = SparkSession.builder.getOrCreate()
 
-df = sqlContext.read.format('com.databricks.spark.xml').options(rowTag='book').load('books.xml')
+df = spark.read.format('com.databricks.spark.xml').options(rowTag='book').load('books.xml')
 df.select("author", "_id").write \
     .format('com.databricks.spark.xml') \
     .options(rowTag='book', rootTag='books') \
@@ -309,10 +309,10 @@ df.select("author", "_id").write \
 
 You can manually specify schema:
 ```python
-from pyspark.sql import SQLContext
+from pyspark.sql import SparkSession
 from pyspark.sql.types import *
 
-sqlContext = SQLContext(sc)
+spark = SparkSession.builder.getOrCreate()
 customSchema = StructType([ \
     StructField("_id", StringType(), True), \
     StructField("author", StringType(), True), \
@@ -322,7 +322,7 @@ customSchema = StructType([ \
     StructField("publish_date", StringType(), True), \
     StructField("title", StringType(), True)])
 
-df = sqlContext.read \
+df = spark.read \
     .format('com.databricks.spark.xml') \
     .options(rowTag='book') \
     .load('books.xml', schema = customSchema)

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ spName := "databricks/spark-xml"
 
 crossScalaVersions := Seq("2.11.12", "2.12.8")
 
+scalacOptions := Seq("-unchecked", "-deprecation")
+
 sparkVersion := sys.props.get("spark.testVersion").getOrElse("2.4.0")
 
 sparkComponents := Seq("core", "sql")

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -16,7 +16,7 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrame, SparkSession, SQLContext}
 import org.apache.spark.sql.types.StructType
 import com.databricks.spark.xml.util.XmlFile
 
@@ -93,7 +93,6 @@ class XmlReader extends Serializable {
   }
 
   /** Returns a Schema RDD for the given XML path. */
-  @throws[RuntimeException]
   def xmlFile(sqlContext: SQLContext, path: String): DataFrame = {
     // We need the `charset` and `rowTag` before creating the relation.
     val (charset, rowTag) = {
@@ -116,4 +115,11 @@ class XmlReader extends Serializable {
       schema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
+
+  def xmlFile(spark: SparkSession, path: String): DataFrame =
+    xmlFile(spark.sqlContext, path)
+
+  def xmlRdd(spark: SparkSession, xmlRDD: RDD[String]): DataFrame =
+    xmlRdd(spark.sqlContext, xmlRDD)
+
 }

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -30,13 +30,12 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
 
 public class JavaXmlSuite {
+    private static final int numBooks = 12;
+    private static final String booksFile = "src/test/resources/books.xml";
+    private static final String booksFileTag = "book";
+    private static final String tempDir = "target/test/xmlData/";
+
     private transient SQLContext sqlContext;
-    private int numBooks = 12;
-
-    String booksFile = "src/test/resources/books.xml";
-    String booksFileTag = "book";
-
-    private String tempDir = "target/test/xmlData/";
 
     @Before
     public void setUp() throws IOException {
@@ -63,7 +62,7 @@ public class JavaXmlSuite {
 
     @Test
     public void testLoad() {
-        HashMap<String, String> options = new HashMap<String, String>();
+        HashMap<String, String> options = new HashMap<>();
         options.put("rowTag", booksFileTag);
         options.put("path", booksFile);
 

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -17,7 +17,6 @@ package com.databricks.spark.xml
 
 import java.io.File
 import java.nio.charset.UnsupportedCharsetException
-import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 
 import scala.io.Source
@@ -28,11 +27,11 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.databricks.spark.xml.XmlOptions._
-import com.databricks.spark.xml.util.{ParseModes, XmlFile}
+import com.databricks.spark.xml.util.ParseModes
 
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Row, SQLContext, SaveMode}
-import org.apache.spark.{SparkConf, SparkContext, SparkException}
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.SparkException
 
 class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val tempEmptyDir = "target/test/empty/"
@@ -76,27 +75,26 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val numGPS = 2
   val numFiasHouses = 37
 
-  private var sqlContext: SQLContext = _
+  private var spark: SparkSession = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    // Fix Spark 2.0.0 on windows, see https://issues.apache.org/jira/browse/SPARK-15893
-    val conf = new SparkConf().set(
-      "spark.sql.warehouse.dir",
-      Files.createTempDirectory("spark-warehouse").toString)
-    sqlContext = new SQLContext(new SparkContext("local[2]", "XmlSuite", conf))
+    spark = SparkSession.builder().
+      master("local[2]").
+      appName("XmlSuite").
+      getOrCreate()
   }
 
   override protected def afterAll(): Unit = {
     try {
-      sqlContext.sparkContext.stop()
+      spark.stop()
     } finally {
       super.afterAll()
     }
   }
 
   test("DSL test") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .load(carsFile)
       .select("year")
       .collect()
@@ -105,7 +103,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test with xml having unbalanced datatypes") {
-    val results = sqlContext.read
+    val results = spark.read
       .option("treatEmptyValuesAsNulls", "true")
       .xml(gpsEmptyField)
 
@@ -113,7 +111,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test with mixed elements (attributes, no child)") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .load(carsMixedAttrNoChildFile)
       .select("date")
       .collect()
@@ -126,7 +124,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test for inconsistent element attributes as fields") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksAttributesInNoChild)
       .select("price")
@@ -143,7 +141,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test with mixed elements (struct, string)") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", agesTag)
       .load(agesMixedTypes)
       .collect()
@@ -151,7 +149,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test with elements in array having attributes") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", agesTag)
       .load(agesFile)
       .collect()
@@ -165,7 +163,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   test("DSL test for iso-8859-1 encoded file") {
     val dataFrame = new XmlReader()
       .withCharset("iso-8859-1")
-      .xmlFile(sqlContext, carsFile8859)
+      .xmlFile(spark, carsFile8859)
     assert(dataFrame.select("year").collect().size === numCars)
 
     val results = dataFrame
@@ -176,7 +174,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test compressed file") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .load(carsFileGzip)
       .select("year")
       .collect()
@@ -185,7 +183,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test splittable compressed file") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .load(carsFileBzip2)
       .select("year")
       .collect()
@@ -195,7 +193,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
   test("DSL test bad charset name") {
     val exception = intercept[UnsupportedCharsetException] {
-      val results = sqlContext.read.format("xml")
+      spark.read.format("xml")
         .option("charset", "1-9588-osi")
         .load(carsFile)
         .select("year")
@@ -205,31 +203,31 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DDL test") {
-    sqlContext.sql(
+    spark.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable1
          |USING com.databricks.spark.xml
          |OPTIONS (path "$carsFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT year FROM carsTable1").collect().size === numCars)
+    assert(spark.sql("SELECT year FROM carsTable1").collect().size === numCars)
   }
 
   test("DDL test with alias name") {
-    sqlContext.sql(
+    spark.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable2
          |USING xml
          |OPTIONS (path "$carsFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT year FROM carsTable2").collect().size === numCars)
+    assert(spark.sql("SELECT year FROM carsTable2").collect().size === numCars)
   }
 
   test("DSL test for parsing a malformed XML file") {
     val results = new XmlReader()
       .withParseMode(ParseModes.DROP_MALFORMED_MODE)
-      .xmlFile(sqlContext, carsMalformedFile)
+      .xmlFile(spark, carsMalformedFile)
 
     assert(results.count() === 1)
   }
@@ -237,7 +235,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   test("DSL test for dropping malformed rows") {
     val cars = new XmlReader()
       .withParseMode(ParseModes.DROP_MALFORMED_MODE)
-      .xmlFile(sqlContext, carsMalformedFile)
+      .xmlFile(spark, carsMalformedFile)
 
     assert(cars.count() == 1)
     assert(cars.head().toSeq === Seq("Chevy", "Volt", 2015))
@@ -247,7 +245,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val exceptionInParse = intercept[SparkException] {
       new XmlReader()
         .withFailFast(true)
-        .xmlFile(sqlContext, carsMalformedFile)
+        .xmlFile(spark, carsMalformedFile)
         .collect()
     }
     assert(exceptionInParse.getMessage.contains("Malformed line in FAILFAST mode"))
@@ -257,7 +255,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val carsDf = new XmlReader()
       .withParseMode(ParseModes.PERMISSIVE_MODE)
       .withColumnNameOfCorruptRecord("_malformed_records")
-      .xmlFile(sqlContext, carsMalformedFile)
+      .xmlFile(spark, carsMalformedFile)
     val cars = carsDf.collect()
     assert(cars.length == 3)
 
@@ -279,7 +277,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   test("DSL test with empty file and known schema") {
     val results = new XmlReader()
       .withSchema(StructType(List(StructField("column", StringType, false))))
-      .xmlFile(sqlContext, emptyFile)
+      .xmlFile(spark, emptyFile)
       .count()
 
     assert(results === 0)
@@ -297,33 +295,33 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     )
     val results = new XmlReader()
       .withSchema(schema)
-      .xmlFile(sqlContext, carsUnbalancedFile)
+      .xmlFile(spark, carsUnbalancedFile)
       .count()
 
     assert(results === numCars)
   }
 
   test("DDL test with empty file") {
-    sqlContext.sql(s"""
+    spark.sql(s"""
            |CREATE TEMPORARY TABLE carsTable3
            |(year double, make string, model string, comments string, grp string)
            |USING com.databricks.spark.xml
            |OPTIONS (path "$emptyFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT count(*) FROM carsTable3").collect().head(0) === 0)
+    assert(spark.sql("SELECT count(*) FROM carsTable3").collect().head(0) === 0)
   }
 
   test("SQL test insert overwrite") {
     TestUtils.deleteRecursively(new File(tempEmptyDir))
     new File(tempEmptyDir).mkdirs()
-    sqlContext.sql(
+    spark.sql(
       s"""
          |CREATE TEMPORARY TABLE booksTableIO
          |USING com.databricks.spark.xml
          |OPTIONS (path "$booksFile", rowTag "$booksTag")
       """.stripMargin.replaceAll("\n", " "))
-    sqlContext.sql(
+    spark.sql(
       s"""
          |CREATE TEMPORARY TABLE booksTableEmpty
          |(author string, description string, genre string,
@@ -332,15 +330,15 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
          |OPTIONS (path "$tempEmptyDir")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT * FROM booksTableIO").collect().size === numBooks)
-    assert(sqlContext.sql("SELECT * FROM booksTableEmpty").collect().isEmpty)
+    assert(spark.sql("SELECT * FROM booksTableIO").collect().size === numBooks)
+    assert(spark.sql("SELECT * FROM booksTableEmpty").collect().isEmpty)
 
-    sqlContext.sql(
+    spark.sql(
       s"""
          |INSERT OVERWRITE TABLE booksTableEmpty
          |SELECT * FROM booksTableIO
       """.stripMargin.replaceAll("\n", " "))
-    assert(sqlContext.sql("SELECT * FROM booksTableEmpty").collect().size == numBooks)
+    assert(spark.sql("SELECT * FROM booksTableEmpty").collect().size == numBooks)
   }
 
   test("DSL save with gzip compression codec") {
@@ -349,7 +347,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     new File(tempEmptyDir).mkdirs()
     val copyFilePath = tempEmptyDir + "cars-copy.xml"
 
-    val cars = sqlContext.read.format("xml").load(carsFile)
+    val cars = spark.read.format("xml").load(carsFile)
     cars.write
       .format("xml")
       .mode(SaveMode.Overwrite)
@@ -359,7 +357,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     // Check that the part file has a .gz extension
     assert(carsCopyPartFile.exists())
 
-    val carsCopy = sqlContext.read.format("xml").load(copyFilePath)
+    val carsCopy = spark.read.format("xml").load(copyFilePath)
 
     assert(carsCopy.count == cars.count)
     assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
@@ -371,7 +369,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     new File(tempEmptyDir).mkdirs()
     val copyFilePath = tempEmptyDir + "cars-copy.xml"
 
-    val cars = sqlContext.read.format("xml").load(carsFile)
+    val cars = spark.read.format("xml").load(carsFile)
     cars.write
       .format("xml")
       .mode(SaveMode.Overwrite)
@@ -382,7 +380,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     // Check that the part file has a .gz extension
     assert(carsCopyPartFile.exists())
 
-    val carsCopy = sqlContext.read.format("xml").load(copyFilePath)
+    val carsCopy = spark.read.format("xml").load(copyFilePath)
 
     assert(carsCopy.count == cars.count)
     assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
@@ -394,7 +392,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     new File(tempEmptyDir).mkdirs()
     val copyFilePath = tempEmptyDir + "books-copy.xml"
 
-    val books = sqlContext.read.format("xml")
+    val books = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksComplicatedFile)
     books.write
@@ -402,7 +400,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .format("xml")
       .save(copyFilePath)
 
-    val booksCopy = sqlContext.read.format("xml")
+    val booksCopy = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(copyFilePath)
     assert(booksCopy.count == books.count)
@@ -415,7 +413,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     new File(tempEmptyDir).mkdirs()
     val copyFilePath = tempEmptyDir + "books-copy.xml"
 
-    val books = sqlContext.read.format("xml")
+    val books = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksComplicatedFile)
     books.write
@@ -423,7 +421,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .format("xml")
       .save(copyFilePath)
 
-    val booksCopy = sqlContext.read.format("xml")
+    val booksCopy = spark.read.format("xml")
       .option("rowTag", booksTag)
       .option("treatEmptyValuesAsNulls", "true")
       .load(copyFilePath)
@@ -439,7 +437,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "books-copy.xml"
 
     val rootTag = "catalog"
-    val books = sqlContext.read.format("xml")
+    val books = spark.read.format("xml")
       .option("valueTag", "#VALUE")
       .option("attributePrefix", "#")
       .option("rowTag", booksTag)
@@ -453,7 +451,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("rowTag", booksTag)
       .save(copyFilePath)
 
-    val booksCopy = sqlContext.read.format("xml")
+    val booksCopy = spark.read.format("xml")
       .option("valueTag", "#VALUE")
       .option("attributePrefix", "_")
       .option("rowTag", booksTag)
@@ -471,9 +469,9 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     val schema = StructType(
       List(StructField("a", ArrayType(ArrayType(StringType)), nullable = true)))
-    val data = sqlContext.sparkContext.parallelize(
+    val data = spark.sparkContext.parallelize(
       List(List(List("aa", "bb"), List("aa", "bb")))).map(Row(_))
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = spark.createDataFrame(data, schema)
     df.write.xml(copyFilePath)
 
     // When [[ArrayType]] has [[ArrayType]] as elements, it is confusing what is the element
@@ -483,7 +481,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       List(StructField("a", ArrayType(
         StructType(List(StructField("item", ArrayType(StringType), nullable = true)))),
           nullable = true)))
-    val dfCopy = sqlContext.read.format("xml").load(copyFilePath)
+    val dfCopy = spark.read.format("xml").load(copyFilePath)
 
     assert(dfCopy.count == df.count)
     assert(dfCopy.schema === schemaCopy)
@@ -516,21 +514,21 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
         1.toByte, 1.toShort, 1, 1.toLong,
         1.toFloat, 1.toDouble, Decimal(1, 25, 3), Decimal(1, 6, 5),
         Date.valueOf(date), Timestamp.valueOf(timestamp), Map("a" -> "b"))
-    val data = sqlContext.sparkContext.parallelize(Seq(row))
+    val data = spark.sparkContext.parallelize(Seq(row))
 
-    val df = sqlContext.createDataFrame(data, schema)
+    val df = spark.createDataFrame(data, schema)
     df.write.format("xml").save(copyFilePath)
 
     val dfCopy = new XmlReader()
       .withSchema(schema)
-      .xmlFile(sqlContext, copyFilePath)
+      .xmlFile(spark, copyFilePath)
 
     assert(dfCopy.collect() === df.collect())
     assert(dfCopy.schema === df.schema)
   }
 
   test("DSL test schema inferred correctly") {
-    val results = sqlContext.read.format("xml").option("rowTag", booksTag).load(booksFile)
+    val results = spark.read.format("xml").option("rowTag", booksTag).load(booksFile)
 
     assert(results.schema == StructType(List(
       StructField(s"${DEFAULT_ATTRIBUTE_PREFIX}id", StringType, nullable = true),
@@ -546,7 +544,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test schema inferred correctly with sampling ratio") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", booksTag)
       .option("samplingRatio", 0.5)
       .load(booksFile)
@@ -565,7 +563,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test schema (object) inferred correctly") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksNestedObjectFile)
 
@@ -584,7 +582,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test schema (array) inferred correctly") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksNestedArrayFile)
 
@@ -602,7 +600,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test schema (complicated) inferred correctly") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", booksTag)
       .load(booksComplicatedFile)
 
@@ -632,7 +630,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     // Default value.
     val resultsOne = new XmlReader()
       .withRowTag(booksTag)
-      .xmlFile(sqlContext, booksAttributesInNoChild)
+      .xmlFile(spark, booksAttributesInNoChild)
 
     val schemaOne = StructType(List(
       StructField("_id", StringType, nullable = true),
@@ -655,7 +653,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .withRowTag(booksTag)
       .withAttributePrefix(attributePrefix)
       .withValueTag(valueTag)
-      .xmlFile(sqlContext, booksAttributesInNoChild)
+      .xmlFile(spark, booksAttributesInNoChild)
 
     val schemaTwo = StructType(List(
       StructField(s"${attributePrefix}id", StringType, nullable = true),
@@ -676,7 +674,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val results = new XmlReader()
       .withExcludeAttribute(true)
       .withRowTag(booksTag)
-      .xmlFile(sqlContext, booksFile)
+      .xmlFile(spark, booksFile)
 
     val schema = StructType(List(
       StructField("author", StringType, nullable = true),
@@ -702,14 +700,14 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     )
     val results = new XmlReader()
       .withSchema(schema)
-      .xmlFile(sqlContext, carsUnbalancedFile)
+      .xmlFile(spark, carsUnbalancedFile)
       .count()
 
     assert(results === numCars)
   }
 
   test("DSL test inferred schema passed through") {
-    val dataFrame = sqlContext.read.format("xml").load(carsFile)
+    val dataFrame = spark.read.format("xml").load(carsFile)
 
     val results = dataFrame
       .select("comment", "year")
@@ -725,7 +723,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       StructField("age", StringType, true) :: Nil)
     val results = new XmlReader()
       .withSchema(schema)
-      .xmlFile(sqlContext, nullNumbersFile)
+      .xmlFile(spark, nullNumbersFile)
       .collect()
 
     assert(results.head.toSeq === Seq("alice", "35"))
@@ -738,14 +736,14 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .withSchema(StructType(List(StructField("name", StringType, false),
       StructField("age", IntegerType, true))))
       .withTreatEmptyValuesAsNulls(true)
-      .xmlFile(sqlContext, nullNumbersFile)
+      .xmlFile(spark, nullNumbersFile)
       .collect()
 
     assert(results(1).toSeq === Seq("bob", null))
   }
 
   test("DSL test with namespaces ignored") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", topicsTag)
       .load(topicsFile)
       .collect()
@@ -754,7 +752,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Missing nested struct represented as null instead of empty Row") {
-    val result = sqlContext.read.format("xml")
+    val result = spark.read.format("xml")
       .option("rowTag", "item")
       .load(nullNestedStructFile)
       .select("b.es")
@@ -774,22 +772,22 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
     val result = new XmlReader()
       .withSchema(schema)
-      .xmlFile(sqlContext, simpleNestedObjects)
+      .xmlFile(spark, simpleNestedObjects)
       .select("c.a", "c.b")
       .collect()
 
     assert(result(0).toSeq === Seq(111, 222))
   }
 
-  test("Nested element with same name as parent delinination") {
+  test("Nested element with same name as parent delineation") {
     val lines = Source.fromFile(nestedElementWithNameOfParent).getLines.toList
     val firstExpected = lines(2).trim
     val lastExpected = lines(3).trim
-    val config = new Configuration(sqlContext.sparkContext.hadoopConfiguration)
+    val config = new Configuration(spark.sparkContext.hadoopConfiguration)
     config.set(XmlInputFormat.START_TAG_KEY, "<parent>")
     config.set(XmlInputFormat.END_TAG_KEY, "</parent>")
     config.set(XmlInputFormat.ENCODING_KEY, "utf-8")
-    val records = sqlContext.sparkContext.newAPIHadoopFile(
+    val records = spark.sparkContext.newAPIHadoopFile(
       nestedElementWithNameOfParent,
       classOf[XmlInputFormat],
       classOf[LongWritable],
@@ -806,7 +804,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   test("Nested element with same name as parent schema inference") {
     val df = new XmlReader()
       .withRowTag("parent")
-      .xmlFile(sqlContext, nestedElementWithNameOfParent)
+      .xmlFile(spark, nestedElementWithNameOfParent)
 
     val nestedSchema = StructType(
       Seq(
@@ -818,15 +816,15 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(df.schema == schema)
   }
 
-  test("Skip and project currecntly XML files without indentation") {
-    val df = sqlContext.read.format("xml").load(carsNoIndentationFile)
+  test("Skip and project currently XML files without indentation") {
+    val df = spark.read.format("xml").load(carsNoIndentationFile)
     val results = df.select("model").collect()
     val years = results.map(_.toSeq.head).toSet
     assert(years == Set("S", "E350", "Volt"))
   }
 
   test("Select correctly all child fields regardless of pushed down projection") {
-    val results = sqlContext.read.format("xml")
+    val results = spark.read.format("xml")
       .option("rowTag", "book")
       .load(booksComplicatedFile)
       .selectExpr("publish_dates")
@@ -839,25 +837,25 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
 
   test("Empty string not allowed for rowTag, attributePrefix and valueTag.") {
     val messageOne = intercept[IllegalArgumentException] {
-      sqlContext.read.format("xml").option("rowTag", "").load(carsFile)
+      spark.read.format("xml").option("rowTag", "").load(carsFile)
     }.getMessage
     assert(messageOne == "requirement failed: 'rowTag' option should not be empty string.")
 
     val messageTwo = intercept[IllegalArgumentException] {
-      sqlContext.read.format("xml").option("attributePrefix", "").load(carsFile)
+      spark.read.format("xml").option("attributePrefix", "").load(carsFile)
     }.getMessage
     assert(
       messageTwo == "requirement failed: 'attributePrefix' option should not be empty string.")
 
     val messageThree = intercept[IllegalArgumentException] {
-      sqlContext.read.format("xml").option("valueTag", "").load(carsFile)
+      spark.read.format("xml").option("valueTag", "").load(carsFile)
     }.getMessage
     assert(messageThree == "requirement failed: 'valueTag' option should not be empty string.")
   }
 
   test("valueTag and attributePrefix should not be the same.") {
     val messageOne = intercept[IllegalArgumentException] {
-      sqlContext.read.format("xml")
+      spark.read.format("xml")
         .option("valueTag", "#abc")
         .option("attributePrefix", "#abc")
         .load(carsFile)
@@ -867,13 +865,13 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("nullValue and treatEmptyValuesAsNulls test") {
-    val resultsOne = sqlContext.read.format("xml")
+    val resultsOne = spark.read.format("xml")
       .option("treatEmptyValuesAsNulls", "true")
       .load(gpsEmptyField)
     assert(resultsOne.selectExpr("extensions.TrackPointExtension").head().isNullAt(0))
     assert(resultsOne.collect().size === numGPS)
 
-    val resultsTwo = sqlContext.read.format("xml")
+    val resultsTwo = spark.read.format("xml")
       .option("nullValue", "2013-01-24T06:18:43Z")
       .load(gpsEmptyField)
     assert(resultsTwo.selectExpr("time").head().isNullAt(0))
@@ -884,7 +882,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val results = new XmlReader()
       .withIgnoreSurroundingSpaces(true)
       .withRowTag(agesTag)
-      .xmlFile(sqlContext, agesWithSpacesFile)
+      .xmlFile(spark, agesWithSpacesFile)
       .collect()
     val attrValOne = results(0).get(0).asInstanceOf[Row](1)
     val attrValTwo = results(1).get(0).asInstanceOf[Row](0)
@@ -897,7 +895,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val results = new XmlReader()
       .withParseMode(ParseModes.DROP_MALFORMED_MODE)
         .withRowTag(booksTag)
-        .xmlFile(sqlContext, booksMalformedAttributes)
+        .xmlFile(spark, booksMalformedAttributes)
         .collect()
 
     assert(results.length === 2)
@@ -906,7 +904,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("read utf-8 encoded file with empty tag") {
-    val df = sqlContext.read.format("xml")
+    val df = spark.read.format("xml")
       .option("excludeAttribute", "false")
       .option("rowTag", fiasRowTag)
       .xml(fiasHouse)

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -88,6 +88,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   override protected def afterAll(): Unit = {
     try {
       spark.stop()
+      spark = null
     } finally {
       super.afterAll()
     }


### PR DESCRIPTION
Use SparkSession in favor of deprecated SQLContext in tests (deprecation warning), and add method that directly accepts SparkSession. Plus minor fixes elsewhere to the code that raise IJ warnings.