### PR TITLE
Rewrite XMLInputFormat in terms of chars not bytes. Fix handling of self-closing tags

### DIFF
--- a/src/test/resources/self-closing-tag.xml
+++ b/src/test/resources/self-closing-tag.xml
@@ -1,0 +1,6 @@
+<ROWSET>
+    <ROW>
+        <non-empty-tag>1</non-empty-tag>
+        <self-closing-tag/>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -63,6 +63,7 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
   val attributesStartWithNewLine = "src/test/resources/attributesStartWithNewLine.xml"
   val attributesStartWithNewLineLF = "src/test/resources/attributesStartWithNewLineLF.xml"
   val attributesStartWithNewLineCR = "src/test/resources/attributesStartWithNewLineCR.xml"
+  val selfClosingTag = "src/test/resources/self-closing-tag.xml"
 
   val booksTag = "book"
   val booksRootTag = "books"
@@ -941,4 +942,19 @@ class XmlSuite extends FunSuite with BeforeAndAfterAll {
       assert(df.count() == rowsCount)
     }
   }
+
+  test("Produces correct result for a row with a self closing tag inside") {
+    val schema = StructType(Seq(
+      StructField("non-empty-tag", IntegerType, nullable = true),
+      StructField("self-closing-tag", IntegerType, nullable = true)
+    ))
+
+    val result = new XmlReader()
+      .withSchema(schema)
+      .xmlFile(spark, selfClosingTag)
+      .collect()
+
+    assert(result(0).toSeq === Seq(1, null))
+  }
+
 }


### PR DESCRIPTION
This should supersede:
- https://github.com/databricks/spark-xml/pull/316
- https://github.com/databricks/spark-xml/pull/321
- https://github.com/databricks/spark-xml/pull/149

To make the fix, it seemed necessary to rewrite the logic in terms of characters, not bytes. Honestly I don't know why the original implementation worked in terms of bytes, even though I might have been part of it.

This does handle self-closing tags, but not nested copies of the same row tag. The latter is either something we need to drop or, will require another rewrite to handle sanely.