### PR TITLE
Remove useless extending TableScan

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,9 @@ val ignoredABIProblems = {
     exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlOptions.permissive"),
     exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlOptions.failFast"),
     exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes"),
-    exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes$")
+    exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes$"),
+    exclude[MissingTypesProblem]("com.databricks.spark.xml.XmlRelation"),
+    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlRelation.buildScan")
   )
 }
 

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -33,7 +33,6 @@ case class XmlRelation protected[spark] (
     userSchema: StructType = null)(@transient val sqlContext: SQLContext)
   extends BaseRelation
   with InsertableRelation
-  with TableScan
   with PrunedScan {
 
   private val options = XmlOptions(parameters)
@@ -46,25 +45,13 @@ case class XmlRelation protected[spark] (
     }
   }
 
-  override def buildScan(): RDD[Row] = {
-    StaxXmlParser.parse(
-      baseRDD(),
-      schema,
-      options)
-  }
-
   override def buildScan(requiredColumns: Array[String]): RDD[Row] = {
     val requiredFields = requiredColumns.map(schema(_))
-    val schemaFields = schema.fields
-    if (schemaFields.deep == requiredFields.deep) {
-      buildScan()
-    } else {
-      val requestedSchema = StructType(requiredFields)
-      StaxXmlParser.parse(
-        baseRDD(),
-        requestedSchema,
-        options)
-    }
+    val requestedSchema = StructType(requiredFields)
+    StaxXmlParser.parse(
+      baseRDD(),
+      requestedSchema,
+      options)
   }
 
   // The function below was borrowed from JSONRelation


### PR DESCRIPTION
We don't need to extend `TableScan` if it implements `PrunedScan`. See https://github.com/apache/spark/blob/5ad03607d1487e7ab3e3b6d00eef9c4028ed4975/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala#L271-L302