### PR TITLE
Support Xml Boolean Lexical Literal 1 and 0 for boolean data type

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -51,8 +51,8 @@ private[xml] object StaxXmlParser extends Serializable {
           throw new RuntimeException(
             s"Malformed line in FAILFAST mode: ${record.replaceAll("\n", "")}", cause)
         case DropMalformedMode =>
-          val reason = if (cause != null) cause.getMessage else "Unknown";
-          logger.warn(s"Dropping malformed line: ${record.replaceAll("\n", "")}, Reason: $reason")
+          val reason = if (cause != null) s"Reason: ${cause.getMessage}" else ""
+          logger.warn(s"Dropping malformed line: ${record.replaceAll("\n", "")}. $reason")
           None
         case PermissiveMode =>
           val row = new Array[Any](schema.length)

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -61,13 +61,23 @@ object TypeCast {
           .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
         case _: DoubleType => Try(datum.toDouble)
           .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
-        case _: BooleanType => datum.toBoolean
+        case _: BooleanType => parseXmlBoolean(datum)
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
         case _: TimestampType => Timestamp.valueOf(datum)
         case _: DateType => Date.valueOf(datum)
         case _: StringType => datum
         case _ => throw new RuntimeException(s"Unsupported type: ${castType.typeName}")
       }
+    }
+  }
+
+  private def parseXmlBoolean(s: String): Boolean = {
+    s.toLowerCase match {
+      case "true" => true
+      case "false" => false
+      case "1" => true
+      case "0" => false
+      case _ => throw new IllegalArgumentException(s"For input string: $s")
     }
   }
 

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -68,9 +68,9 @@ final class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1.00", FloatType, options) === 1.0)
     assert(TypeCast.castTo("1.00", DoubleType, options) === 1.0)
     assert(TypeCast.castTo("true", BooleanType, options) === true)
-    assert(TypeCast.castTo("1", BooleanType, options) == true)
-    assert(TypeCast.castTo("false", BooleanType, options) == false)
-    assert(TypeCast.castTo("0", BooleanType, options) == false)
+    assert(TypeCast.castTo("1", BooleanType, options) === true)
+    assert(TypeCast.castTo("false", BooleanType, options) === false)
+    assert(TypeCast.castTo("0", BooleanType, options) === false)
     val timestamp = "2015-01-01 00:00:00"
     assert(
       TypeCast.castTo(timestamp, TimestampType, options) === Timestamp.valueOf(timestamp))

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -68,6 +68,9 @@ final class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1.00", FloatType, options) === 1.0)
     assert(TypeCast.castTo("1.00", DoubleType, options) === 1.0)
     assert(TypeCast.castTo("true", BooleanType, options) === true)
+    assert(TypeCast.castTo("1", BooleanType, options) == true)
+    assert(TypeCast.castTo("false", BooleanType, options) == false)
+    assert(TypeCast.castTo("0", BooleanType, options) == false)
     val timestamp = "2015-01-01 00:00:00"
     assert(
       TypeCast.castTo(timestamp, TimestampType, options) === Timestamp.valueOf(timestamp))


### PR DESCRIPTION
Added Support for supporting xsd boolean lexical literals 1, 0 along with true and false.
Added clause in the throws exception (in case of FAILFAST mode) to add root cause.