### PR TITLE
Alternate take on continuing parsing rows in permissive mode

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -110,7 +110,7 @@ private[xml] object StaxXmlParser extends Serializable {
 
     (parser.peek, dataType) match {
       case (_: StartElement, dt: DataType) => convertComplicatedType(dt)
-      case (_: EndElement, dt: StringType) =>
+      case (_: EndElement, _: StringType) =>
         if (options.treatEmptyValuesAsNulls){
           null
         } else {
@@ -158,12 +158,15 @@ private[xml] object StaxXmlParser extends Serializable {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          keys += e.getName.getLocalPart
-          values += convertField(parser, valueType, options)
+          try {
+            keys += e.getName.getLocalPart
+            values += convertField(parser, valueType, options)
+          } catch {
+            case NonFatal(_) if options.parseMode == PermissiveMode => // do nothing
+          }
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
-        case _ =>
-          shouldStop = shouldStop && parser.hasNext
+        case _ => // do nothing
       }
     }
     keys.zip(values).toMap
@@ -179,9 +182,13 @@ private[xml] object StaxXmlParser extends Serializable {
     val convertedValuesMap = collection.mutable.Map.empty[String, Any]
     val valuesMap = StaxXmlParserUtils.convertAttributesToValuesMap(attributes, options)
     valuesMap.foreach { case (f, v) =>
-      val nameToIndex = schema.map(_.name).zipWithIndex.toMap
-      nameToIndex.get(f).foreach { i =>
-        convertedValuesMap(f) = convertTo(v, schema(i).dataType, options)
+      try {
+        val nameToIndex = schema.map(_.name).zipWithIndex.toMap
+        nameToIndex.get(f).foreach { i =>
+          convertedValuesMap(f) = convertTo(v, schema(i).dataType, options)
+        }
+      } catch {
+        case NonFatal(_) if options.parseMode == PermissiveMode => // do nothing
       }
     }
     convertedValuesMap.toMap
@@ -204,17 +211,23 @@ private[xml] object StaxXmlParser extends Serializable {
     val attributesMap = convertAttributes(attributes, schema, options)
 
     // Then, we read elements here.
-    val fieldsMap = convertField(parser, schema, options) match {
-      case row: Row =>
-        Map(schema.map(_.name).zip(row.toSeq): _*)
-      case v if schema.fieldNames.contains(options.valueTag) =>
-        // If this is the element having no children, then it wraps attributes
-        // with a row So, we first need to find the field name that has the real
-        // value and then push the value.
-        val valuesMap = schema.fieldNames.map((_, null)).toMap
-        valuesMap + (options.valueTag -> v)
-      case _ => Map.empty
-    }
+    val fieldsMap =
+      try {
+        convertField(parser, schema, options) match {
+          case row: Row =>
+            Map(schema.map(_.name).zip(row.toSeq): _*)
+          case v if schema.fieldNames.contains(options.valueTag) =>
+            // If this is the element having no children, then it wraps attributes
+            // with a row So, we first need to find the field name that has the real
+            // value and then push the value.
+            val valuesMap = schema.fieldNames.map((_, null)).toMap
+            valuesMap + (options.valueTag -> v)
+          case _ => Map.empty
+        }
+      } catch {
+        case NonFatal(_) if options.parseMode == PermissiveMode =>
+          Map.empty
+      }
 
     // Here we merge both to a row.
     val valuesMap = fieldsMap ++ attributesMap
@@ -250,42 +263,45 @@ private[xml] object StaxXmlParser extends Serializable {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
-          val field = e.asStartElement.getName.getLocalPart
+          try {
+            val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
+            val field = e.asStartElement.getName.getLocalPart
 
-          nameToIndex.get(field) match {
-            case Some(index) =>
-              schema(index).dataType match {
-                case st: StructType =>
-                  row(index) = convertObjectWithAttributes(parser, st, options, attributes)
+            nameToIndex.get(field) match {
+              case Some(index) =>
+                schema(index).dataType match {
+                  case st: StructType =>
+                    row(index) = convertObjectWithAttributes(parser, st, options, attributes)
 
-                case ArrayType(dt: DataType, _) =>
-                  val values = Option(row(index))
-                    .map(_.asInstanceOf[ArrayBuffer[Any]])
-                    .getOrElse(ArrayBuffer.empty[Any])
-                  val newValue = {
-                    dt match {
-                      case st: StructType =>
-                        convertObjectWithAttributes(parser, st, options, attributes)
-                      case dt: DataType =>
-                        convertField(parser, dt, options)
+                  case ArrayType(dt: DataType, _) =>
+                    val values = Option(row(index))
+                      .map(_.asInstanceOf[ArrayBuffer[Any]])
+                      .getOrElse(ArrayBuffer.empty[Any])
+                    val newValue = {
+                      dt match {
+                        case st: StructType =>
+                          convertObjectWithAttributes(parser, st, options, attributes)
+                        case dt: DataType =>
+                          convertField(parser, dt, options)
+                      }
                     }
-                  }
-                  row(index) = values :+ newValue
+                    row(index) = values :+ newValue
 
-                case dt: DataType =>
-                  row(index) = convertField(parser, dt, options)
-              }
+                  case dt: DataType =>
+                    row(index) = convertField(parser, dt, options)
+                }
 
-            case None =>
-              StaxXmlParserUtils.skipChildren(parser)
+              case None =>
+                StaxXmlParserUtils.skipChildren(parser)
+            }
+          } catch {
+            case NonFatal(_) if options.parseMode == PermissiveMode => // do nothing
           }
 
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
 
-        case _ =>
-          shouldStop = shouldStop && parser.hasNext
+        case _ => // do nothing
       }
     }
     Row.fromSeq(row)

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -219,8 +219,7 @@ private[xml] object InferSchema {
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
 
-        case _ =>
-          shouldStop = shouldStop && parser.hasNext
+        case _ => // do nothing
       }
     }
     // We need to manually merges the fields having the sames so that

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -22,7 +22,6 @@ import java.util.Locale
 
 import scala.util.Try
 import scala.util.control.Exception._
-import scala.util.control.NonFatal
 
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions
@@ -81,25 +80,21 @@ object TypeCast {
     } else {
       datum
     }
-    try {
-      dataType match {
-        case NullType => castTo(value, StringType, options)
-        case LongType => signSafeToLong(value, options)
-        case DoubleType => signSafeToDouble(value, options)
-        case BooleanType => castTo(value, BooleanType, options)
-        case StringType => castTo(value, StringType, options)
-        case DateType => castTo(value, DateType, options)
-        case TimestampType => castTo(value, TimestampType, options)
-        case FloatType => signSafeToFloat(value, options)
-        case ByteType => castTo(value, ByteType, options)
-        case ShortType => castTo(value, ShortType, options)
-        case IntegerType => signSafeToInt(value, options)
-        case dt: DecimalType => castTo(value, dt, options)
-        case _ =>
-          sys.error(s"Failed to parse a value for data type $dataType.")
-      }
-    } catch {
-      case NonFatal(_) if options.parseMode == PermissiveMode => null
+    dataType match {
+      case NullType => castTo(value, StringType, options)
+      case LongType => signSafeToLong(value, options)
+      case DoubleType => signSafeToDouble(value, options)
+      case BooleanType => castTo(value, BooleanType, options)
+      case StringType => castTo(value, StringType, options)
+      case DateType => castTo(value, DateType, options)
+      case TimestampType => castTo(value, TimestampType, options)
+      case FloatType => signSafeToFloat(value, options)
+      case ByteType => castTo(value, ByteType, options)
+      case ShortType => castTo(value, ShortType, options)
+      case IntegerType => signSafeToInt(value, options)
+      case dt: DecimalType => castTo(value, dt, options)
+      case _ =>
+        sys.error(s"Failed to parse a value for data type $dataType.")
     }
   }
 

--- a/src/test/resources/datatypes-valid-and-invalid.xml
+++ b/src/test/resources/datatypes-valid-and-invalid.xml
@@ -9,6 +9,10 @@
         <string_value>Ten</string_value>
         <integer_array>1</integer_array>
         <integer_array>2</integer_array>
+        <integer_map>
+          <b>345</b>
+          <a>123</a>
+        </integer_map>
     </ROW>
     <ROW>
         <integer_value int="Ten">Ten</integer_value>
@@ -19,5 +23,9 @@
         <string_value>Ten</string_value>
         <integer_array>Ten</integer_array>
         <integer_array>2</integer_array>
+        <integer_map>
+          <b>345</b>
+          <a>OneTwoThree</a>
+        </integer_map>
     </ROW>
 </ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -985,32 +985,22 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       field("double_value", DoubleType),
       field("boolean_value", BooleanType),
       field("string_value"),
-      array("integer_array", IntegerType))
+      array("integer_array", IntegerType),
+      StructField("integer_map", MapType(StringType, IntegerType)))
     val results = spark.read
       .option("mode", "PERMISSIVE")
       .schema(schema)
       .xml(dataTypesValidAndInvalid)
 
     assert(results.schema === schema)
-    val objects = results.take(2)
-    assert(objects(0).getStruct(0)(0) === 10)
-    assert(objects(0).getStruct(0)(1) === 10)
-    assert(objects(0).getStruct(1)(0) === 10L)
-    assert(objects(0).getStruct(1)(1) === null)
-    assert(objects(0)(2) === 10.0)
-    assert(objects(0)(3) === 10.0)
-    assert(objects(0)(4) === true)
-    assert(objects(0)(5) === "Ten")
-    assert(objects(0)(6) === Array(1, 2))
-    assert(objects(1).getStruct(0)(0) === null)
-    assert(objects(1).getStruct(0)(1) === null)
-    assert(objects(1).getStruct(1)(0) === null)
-    assert(objects(1).getStruct(1)(1) === 10)
-    assert(objects(1)(2) === null)
-    assert(objects(1)(3) === null)
-    assert(objects(1)(4) === null)
-    assert(objects(1)(5) === "Ten")
-    assert(objects(1)(6) === Array(null, 2))
+
+    val Array(valid, invalid) = results.take(2)
+    assert(valid.toSeq.toArray ===
+      Array(Row(10, 10), Row(10L, null), 10.0, 10.0, true,
+        "Ten", Array(1, 2), Map("a" -> 123, "b" -> 345)))
+    assert(invalid.toSeq.toArray ===
+      Array(Row(null, null), Row(null, 10), null, null, null,
+        "Ten", Array(2), Map("b" -> 345)))
   }
 
 }


### PR DESCRIPTION
See also https://github.com/databricks/spark-xml/pull/358

Alternate take on continuing parsing rows in permissive mode; add test for Map and don't add null array/map entry where invalid.

Much of the change is minor cleanup while trying to debug; the `shouldStop = shouldStop &&` conditions were always no-ops for instance.

I added a Map field to the test case.

In the end it's a more complex but maybe slightly more robust change as it handles errors in more places. It does change the answers slightly. In the case of an array field parsing:

```
        <integer_array>Ten</integer_array>
        <integer_array>2</integer_array>
```

The answer is now an array `[2]` not `[null, 2]`. I think that makes a little more sense. Fields that aren't parsed are `null` because something has to be its value. But adding an entry that's `null` to represent something that's invalid seems a little worse than adding nothing.

CC @Woffendm