### PR TITLE
Define simple methods instead of function objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,13 @@ val ignoredABIProblems = {
     exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes"),
     exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes$"),
     exclude[MissingTypesProblem]("com.databricks.spark.xml.XmlRelation"),
-    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlRelation.buildScan")
+    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlRelation.buildScan"),
+    exclude[DirectMissingMethodProblem](
+      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$" +
+        "spark$xml$parsers$StaxXmlParser$$convertObject$default$4"),
+    exclude[DirectMissingMethodProblem](
+      "com.databricks.spark.xml.util.CompressionCodecs.getCodecClass")
+
   )
 }
 

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -101,8 +101,8 @@ private[xml] object StaxXmlParser extends Serializable {
       parser: XMLEventReader,
       dataType: DataType,
       options: XmlOptions): Any = {
-    def convertComplicatedType: DataType => Any = {
-      case dt: StructType => convertObject(parser, dt, options)
+    def convertComplicatedType(dt: DataType): Any = dt match {
+      case st: StructType => convertObject(parser, st, options)
       case MapType(StringType, vt, _) => convertMap(parser, vt, options)
       case ArrayType(st, _) => convertField(parser, st, options)
       case _: StringType => StaxXmlParserUtils.currentStructureAsString(parser)
@@ -110,7 +110,7 @@ private[xml] object StaxXmlParser extends Serializable {
 
     (parser.peek, dataType) match {
       case (_: StartElement, dt: DataType) => convertComplicatedType(dt)
-      case (_: EndElement, dt: StringType) =>
+      case (_: EndElement, _: StringType) =>
         if (options.treatEmptyValuesAsNulls){
           null
         } else {

--- a/src/main/scala/com/databricks/spark/xml/util/CompressionCodecs.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/CompressionCodecs.scala
@@ -15,6 +15,8 @@
  */
 package com.databricks.spark.xml.util
 
+import java.util.Locale
+
 import scala.util.control.Exception._
 
 import org.apache.hadoop.io.compress._
@@ -32,16 +34,16 @@ private[xml] object CompressionCodecs {
   /**
    * Return the codec class of the given name.
    */
-  def getCodecClass: String => Class[_ <: CompressionCodec] = {
+  def getCodecClass(name: String): Class[_ <: CompressionCodec] = name match {
     case null => null
     case codec =>
-      val codecName = shortCompressionCodecNames.getOrElse(codec.toLowerCase, codec)
+      val codecName = shortCompressionCodecNames.getOrElse(codec.toLowerCase(Locale.ROOT), codec)
       try {
         // scalastyle:off classforname
         Class.forName(codecName).asInstanceOf[Class[CompressionCodec]]
         // scalastyle:on classforname
       } catch {
-        case e: ClassNotFoundException =>
+        case _: ClassNotFoundException =>
           throw new IllegalArgumentException(s"Codec [$codecName] is not " +
             s"available. Known codecs are ${shortCompressionCodecNames.keys.mkString(", ")}.")
       }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -242,7 +242,7 @@ private[xml] object InferSchema {
   /**
    * Convert NullType to StringType and remove StructTypes with no fields
    */
-  private def canonicalizeType: DataType => Option[DataType] = {
+  private def canonicalizeType(dt: DataType): Option[DataType] = dt match {
     case at @ ArrayType(elementType, _) =>
       for {
         canonicalType <- canonicalizeType(elementType)


### PR DESCRIPTION
More just kinda cleanup... in several places a function is defined that returns a function object, but is just invoked like a function. I think they can be simple methods?