### PR TITLE
Produces partial results and also fills corrupt record

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/PartialResultException.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/PartialResultException.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.xml.util
+
+import org.apache.spark.sql.Row
+
+/**
+ * Exception thrown when the underlying parser returns a partial result of parsing.
+ * @param partialResult the partial result of parsing a bad record.
+ * @param cause the actual exception about why the parser cannot return full result.
+ */
+case class PartialResultException(
+    partialResult: Row,
+    cause: Throwable)
+  extends Exception(cause)


### PR DESCRIPTION
Followup for #368.

This PR proposes to produces partial results and also fills corrupt record. Some codes changes were borrowed from the resent change in Apache Spark (https://github.com/apache/spark/commit/4e1d859c19d3bfdfcb8acf915a97c68633b9ca95). That fix allow partial fields in JSON.

This PR fixes:
- Don't allow partial results within array and map (to match with Apache side)
- Partially parse and convert each value in each row. If it fails to parse or convert, it becomes `null`.
  - Partial results are only allowed in the top-level row. For instance,  nested partial result case like `Row(1, Row(1, 2, null))` is disallowed - it becomes `Row(1, null)`.
- If any exception is detected, the whole XML text is placed in `columnNameOfCorruptRecord` record
