### PR TITLE
Add support of custom column infer strategy #205

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When reading files the API accepts several options:
     * When it encounters a field of the wrong datatype, it sets the offending field to `null`.
   * `DROPMALFORMED` : ignores the whole corrupted records.
   * `FAILFAST` : throws an exception when it meets corrupted records.
+* `inferSchema`: if `true`, attempts to infer an appropriate type for each resulting DataFrame column, like a boolean, numeric or date type. If `false`, all resulting columns are of string type. Default is `true`.
 * `columnNameOfCorruptRecord`: The name of new field where malformed strings are stored. Default is `_corrupt_record`.
 * `attributePrefix`: The prefix for attributes so that we can differentiate attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -51,6 +51,7 @@ private[xml] class XmlOptions(
   val ignoreSurroundingSpaces =
     parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
   val parseMode = ParseMode.fromString(parameters.getOrElse("mode", PermissiveMode.name))
+  val inferSchema = parameters.get("inferSchema").map(_.toBoolean).getOrElse(true)
 }
 
 private[xml] object XmlOptions {

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -125,15 +125,19 @@ private[xml] object InferSchema {
       datum
     }
 
-    value match {
-      case null => NullType
-      case v if v.isEmpty => NullType
-      case v if isLong(v) => LongType
-      case v if isInteger(v) => IntegerType
-      case v if isDouble(v) => DoubleType
-      case v if isBoolean(v) => BooleanType
-      case v if isTimestamp(v) => TimestampType
-      case _ => StringType
+    if (options.inferSchema) {
+      value match {
+        case null => NullType
+        case v if v.isEmpty => NullType
+        case v if isLong(v) => LongType
+        case v if isInteger(v) => IntegerType
+        case v if isDouble(v) => DoubleType
+        case v if isBoolean(v) => BooleanType
+        case v if isTimestamp(v) => TimestampType
+        case _ => StringType
+      }
+    } else {
+      StringType
     }
   }
 

--- a/src/test/resources/textColumn.xml
+++ b/src/test/resources/textColumn.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <col1>00010</col1> <!--We like to treat this column as text instead of integer-->
+        <col2>value1</col2>
+        <col3>0.00100</col3>
+    </ROW>
+    <ROW>
+        <col1>00023</col1>
+        <col2>value2</col2>
+        <col3>0.00200</col3>
+    </ROW>
+    <ROW>
+        <col1>00025</col1>
+        <col2>value3</col2>
+        <col3>0.00300</col3>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -73,6 +73,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
   private val attributesStartWithNewLineLF = resDir + "attributesStartWithNewLineLF.xml"
   private val attributesStartWithNewLineCR = resDir + "attributesStartWithNewLineCR.xml"
   private val selfClosingTag = resDir + "self-closing-tag.xml"
+  private val textColumn = resDir + "textColumn.xml"
 
   private val booksTag = "book"
   private val booksRootTag = "books"
@@ -1026,6 +1027,23 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("nullValue", "")
       .xml(nullEmptyStringFile)
     assert(fruit.head().getAs[String]("color") === null)
+  }
+
+  test("test all string data type infer strategy") {
+    val text = spark.read
+      .option("rowTag", "ROW")
+      .option("inferSchema", "false")
+      .xml(textColumn)
+    assert(text.head().getAs[String]("col1") === "00010")
+
+  }
+
+  test("test default data type infer strategy") {
+    val defualt = spark.read
+      .option("rowTag", "ROW")
+      .option("inferSchema", "true")
+      .xml(textColumn)
+    assert(defualt.head().getAs[Int]("col1") === 10)
   }
 
 }


### PR DESCRIPTION
**Background**
Discussion of support all string type column inferring strategy.
Issues : https://github.com/databricks/spark-xml/issues/205

**Use case**
Want to use column inferring to take advantage of no predefined schema.
But want to treat every data as plain text instead of parsed one.

Ex: value “00010” will be inferred as long type and data becomes 10.
It’s not possible to recover data from 10 to “00010” during processing.

**Proposed Solution**
Add interface for custom column data type inferring strategy.

**Modification**
Add interface for column infer strategy.
Add new column infer strategy to treat every column as string.
Add unit test for default, all string infer strategy.

**Test result**
Pass scalastyle, all unit tests, local integration test.

Please let me know if there is any feedback on this pull request.
Thanks.
