### PR TITLE
Ignore processing instructions to fix errors caused by them

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -85,8 +85,11 @@ private[xml] object StaxXmlParser extends Serializable {
       factory.setProperty(XMLInputFactory.IS_COALESCING, true)
       val filter = new EventFilter {
         override def accept(event: XMLEvent): Boolean =
-          // Ignore comments. This library does not treat comments.
-          event.getEventType != XMLStreamConstants.COMMENT
+          // Ignore comments and processing instructions
+          event.getEventType match {
+            case XMLStreamConstants.COMMENT | XMLStreamConstants.PROCESSING_INSTRUCTION => false
+            case _ => true
+          }
       }
 
       iter.flatMap { xml =>

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -86,8 +86,11 @@ private[xml] object InferSchema {
       factory.setProperty(XMLInputFactory.IS_COALESCING, true)
       val filter = new EventFilter {
         override def accept(event: XMLEvent): Boolean =
-          // Ignore comments. This library does not treat comments.
-          event.getEventType != XMLStreamConstants.COMMENT
+          // Ignore comments and processing instructions
+          event.getEventType match {
+            case XMLStreamConstants.COMMENT | XMLStreamConstants.PROCESSING_INSTRUCTION => false
+            case _ => true
+          }
       }
 
       iter.flatMap { xml =>

--- a/src/test/resources/processing.xml
+++ b/src/test/resources/processing.xml
@@ -1,0 +1,6 @@
+<foo>
+  <bar>
+    <?issue?>
+    lorem ipsum
+  </bar>
+</foo>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1046,7 +1046,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .xml(textColumn)
     assert(default.head().getAs[Int]("col1") === 10)
   }
-  
+
   test("test XML with processing instruction") {
     val processingDF = spark.read
       .option("rowTag", "foo")

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1052,7 +1052,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("rowTag", "foo")
       .option("inferSchema", "true")
       .xml(processing)
-    processingDF.show()
+    assert(processingDF.count() === 1)
   }
 
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -74,6 +74,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
   private val attributesStartWithNewLineCR = resDir + "attributesStartWithNewLineCR.xml"
   private val selfClosingTag = resDir + "self-closing-tag.xml"
   private val textColumn = resDir + "textColumn.xml"
+  private val processing = resDir + "processing.xml"
 
   private val booksTag = "book"
   private val booksRootTag = "books"
@@ -1039,11 +1040,19 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("test default data type infer strategy") {
-    val defualt = spark.read
+    val default = spark.read
       .option("rowTag", "ROW")
       .option("inferSchema", "true")
       .xml(textColumn)
-    assert(defualt.head().getAs[Int]("col1") === 10)
+    assert(default.head().getAs[Int]("col1") === 10)
+  }
+  
+  test("test XML with processing instruction") {
+    val processingDF = spark.read
+      .option("rowTag", "foo")
+      .option("inferSchema", "true")
+      .xml(processing)
+    processingDF.show()
   }
 
 }


### PR DESCRIPTION
Simply ignore processing instructions, or else it will cause schema inference and parsing to fail when included inside an element.

Closes #411 