### PR TITLE
Handle character elements mixed text/node elements

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -154,11 +154,34 @@ private[xml] object StaxXmlParser extends Serializable {
       case (c: Characters, ArrayType(st, _)) =>
         // For `ArrayType`, it needs to return the type of element. The values are merged later.
         convertTo(c.getData, st, options)
-      case (c: Characters, st: StructType) =>
-        // This case can be happen when current data type is inferred as `StructType`
-        // due to `valueTag` for elements having attributes but no child.
-        val dt = st.filter(_.name == options.valueTag).head.dataType
-        convertTo(c.getData, dt, options)
+      case (c: Characters, st: StructType) if st.fields.map(_.name).contains(options.valueTag) =>
+        // If a value tag is present, this can be an attribute-only element whose values is in that
+        // value tag field. Or, it can be a mixed-type element with both a character body and other
+        // complex structure. First get the _leading_ character value only (any other separate
+        // character elements are ignored)
+        val dt = st.find(_.name == options.valueTag).get.dataType
+        val value = convertTo(c.getData, dt, options)
+        val attributesOnly = st.fields.forall { f =>
+          f.name == options.valueTag || f.name.startsWith(options.attributePrefix)
+        }
+        if (attributesOnly) {
+          // If everything else is an attribute column, there's no complex structure.
+          // Just return the value of the character element
+          value
+        } else {
+          // Otherwise, consume this text element, and continue parsing the following complex
+          // structure
+          parser.next
+          val valueTagIndex = st.indexWhere(_.name == options.valueTag)
+          val restOfRow = convertObject(
+            parser, StructType(st.filterNot(_.name == options.valueTag)), options).toSeq
+          // stitch the result back together to match the schema
+          val row = new Array[Any](st.fields.length + 1)
+          for (i <- 0 until valueTagIndex) row(i) = restOfRow(i)
+          row(valueTagIndex) = value
+          for (i <- valueTagIndex until restOfRow.length) row(i + 1) = restOfRow(i)
+          Row.fromSeq(row)
+        }
       case (c: Characters, dt: DataType) =>
         convertTo(c.getData, dt, options)
       case (e: XMLEvent, dt: DataType) =>

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -163,8 +163,22 @@ private[xml] object InferSchema {
           case _ => inferField(parser, options)
         }
       case c: Characters if !c.isWhiteSpace =>
-        // This means data exists
-        inferFrom(c.getData, options)
+        // This could be the characters of a character-only element, or could have mixed
+        // characters and other complex structure
+        val characterType = inferFrom(c.getData, options)
+        parser.nextEvent()
+        parser.peek match {
+          case _: StartElement =>
+            // Some more elements follow; parse their schema too. Note that no other
+            // character elements will be handled.
+            val builder = Array.newBuilder[StructField]
+            builder += StructField(options.valueTag, characterType, nullable = true)
+            builder ++= inferObject(parser, options).asInstanceOf[StructType].fields
+            StructType(builder.result())
+          case _ =>
+            // That's all, just the character-only body; use that as the type
+            characterType
+        }
       case e: XMLEvent =>
         throw new IllegalArgumentException(s"Failed to parse data with unexpected event $e")
     }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -169,12 +169,9 @@ private[xml] object InferSchema {
         parser.nextEvent()
         parser.peek match {
           case _: StartElement =>
-            // Some more elements follow; parse their schema too. Note that no other
-            // character elements will be handled.
-            val builder = Array.newBuilder[StructField]
-            builder += StructField(options.valueTag, characterType, nullable = true)
-            builder ++= inferObject(parser, options).asInstanceOf[StructType].fields
-            StructType(builder.result())
+            // Some more elements follow; so ignore the characters.
+            // Use the schema of the rest
+            inferObject(parser, options).asInstanceOf[StructType]
           case _ =>
             // That's all, just the character-only body; use that as the type
             characterType

--- a/src/test/resources/mixed_children.xml
+++ b/src/test/resources/mixed_children.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <foo> issue <bar> lorem </bar> text ignored </foo>
+  <missing> ipsum </missing>
+</root>

--- a/src/test/resources/mixed_children_2.xml
+++ b/src/test/resources/mixed_children_2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <foo> 3.0 <bar> lorem </bar> text ignored <baz><bing>2</bing></baz> text ignored </foo>
+  <missing> ipsum </missing>
+</root>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -75,6 +75,8 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
   private val selfClosingTag = resDir + "self-closing-tag.xml"
   private val textColumn = resDir + "textColumn.xml"
   private val processing = resDir + "processing.xml"
+  private val mixedChildren = resDir + "mixed_children.xml"
+  private val mixedChildren2 = resDir + "mixed_children_2.xml"
 
   private val booksTag = "book"
   private val booksRootTag = "books"
@@ -1053,6 +1055,25 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("inferSchema", "true")
       .xml(processing)
     assert(processingDF.count() === 1)
+  }
+
+  test("test mixed text and element children") {
+    val mixedDF = spark.read
+      .option("rowTag", "root")
+      .option("inferSchema", true)
+      .xml(mixedChildren)
+    val mixedRow = mixedDF.head()
+    assert(mixedRow.getAs[Row](0).toSeq === Seq(" issue ", " lorem "))
+    assert(mixedRow.getString(1) === " ipsum ")
+  }
+
+  test("test mixed text and complex element children") {
+    val mixedDF = spark.read
+      .option("rowTag", "root")
+      .option("inferSchema", true)
+      .xml(mixedChildren2)
+    assert(mixedDF.select("foo._VALUE").head().getDouble(0) === 3.0)
+    assert(mixedDF.select("foo.baz.bing").head().getLong(0) === 2)
   }
 
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1063,7 +1063,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("inferSchema", true)
       .xml(mixedChildren)
     val mixedRow = mixedDF.head()
-    assert(mixedRow.getAs[Row](0).toSeq === Seq(" issue ", " lorem "))
+    assert(mixedRow.getAs[Row](0).toSeq === Seq(" lorem "))
     assert(mixedRow.getString(1) === " ipsum ")
   }
 
@@ -1072,8 +1072,9 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
       .option("rowTag", "root")
       .option("inferSchema", true)
       .xml(mixedChildren2)
-    assert(mixedDF.select("foo._VALUE").head().getDouble(0) === 3.0)
+    assert(mixedDF.select("foo.bar").head().getString(0) === " lorem ")
     assert(mixedDF.select("foo.baz.bing").head().getLong(0) === 2)
+    assert(mixedDF.select("missing").head().getString(0) === " ipsum ")
   }
 
 }


### PR DESCRIPTION
(Don't merge this yet)

See https://github.com/databricks/spark-xml/issues/415 for a bug report. There are two issues:
1. We don't really handle mixed text / node children of elements, possibly by design
2. But, their presence in this example causes the rest of the normal XML to not be parsed correctly

We need to fix the second, I think, one way or the other. 

What about the first?

The conceptual issue is that an element may have character elements all over the place between its child nodes. What does that map to in a schema?
1. an array of strings under the same `_VALUE` element we use for the body of an element with attributes?
2. same, but one joined string?
3. same, but just the first string

Number 2 doesn't quite make sense as there's no conceptual reason to join them. Number 1 does, but, after hacking on this, looks like it's quite hard to implement. Number 3 was hackable; that's this PR. But I don't feel great about it, especially as it's a halfway design, to just take the first character element child and use that, and drop the others. (That would have, however, addressed the first issue in this particular #415 )

Another approach is to simply _correctly_ ignore all of that text. That is, just fix the second issue above.

That I think is also possible via a simplified version of this change.

I'm putting this out for conversation before going that way though.