### PR TITLE
Flush indenting XML writer to make sure one element is written per 'line' in the Hadoop output

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -101,6 +101,7 @@ private[xml] object XmlFile {
                 rowSchema,
                 indentingXmlWriter,
                 options)(iter.next())
+              indentingXmlWriter.flush()
               writer.toString
             }
             writer.reset()


### PR DESCRIPTION
Really simple change, but really important. The code clearly intends to output the XML for one row as the output record that is then written with TextOutputFormat. However, after writing, the `indentingXmlWriter`'s buffer may not be full, and the part that made it to `writer` is incomplete. The rest will be written with the next record, yes, but, TextOutputFormat will put its line separator between the output. This could land right in the middle of a tag or worse.

The tests passed without this change as it seems to only affect Hadoop 2.8 or so and later, probably because some defaults changed somewhere about buffers, etc. However, I think the theoretical issue still is there for all versions.

If I'm right, this fixes at least #338 and #414