### PR TITLE
Add setting to validate rows against an XSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ When reading files the API accepts several options:
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
 * `ignoreSurroundingSpaces`: Defines whether or not surrounding whitespaces from values being read should be skipped. Default is false.
+* `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. New in 0.8.0.
 
 When writing files the API accepts several options:
 * `path`: Location to write files.

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -52,6 +52,7 @@ private[xml] class XmlOptions(
     parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
   val parseMode = ParseMode.fromString(parameters.getOrElse("mode", PermissiveMode.name))
   val inferSchema = parameters.get("inferSchema").map(_.toBoolean).getOrElse(true)
+  val rowValidationXSDPath = parameters.get("rowValidationXSDPath").orNull
 }
 
 private[xml] object XmlOptions {

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -93,6 +93,11 @@ class XmlReader extends Serializable {
     this
   }
 
+  def withRowValidationXSDPath(path: String): XmlReader = {
+    parameters += ("rowValidationXSDPath" -> path)
+    this
+  }
+
   def xmlFile(spark: SparkSession, path: String): DataFrame = {
     // We need the `charset` and `rowTag` before creating the relation.
     val (charset, rowTag) = {

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -16,10 +16,13 @@
 package com.databricks.spark.xml.parsers
 
 import java.io.StringReader
+import java.nio.file.Paths
 
-import javax.xml.stream.events.{Attribute, XMLEvent}
-import javax.xml.stream.events._
-import javax.xml.stream._
+import javax.xml.XMLConstants
+import javax.xml.stream.{EventFilter, XMLEventReader, XMLInputFactory, XMLStreamConstants}
+import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
+import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.SchemaFactory
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConverters._
@@ -92,12 +95,22 @@ private[xml] object StaxXmlParser extends Serializable {
           }
       }
 
+      val xsdSchema = Option(options.rowValidationXSDPath).map { schemaFile =>
+        val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+        schemaFactory.newSchema(Paths.get(schemaFile).toFile)
+      }
+
       iter.flatMap { xml =>
-        // It does not have to skip for white space, since `XmlInputFormat`
-        // always finds the root tag without a heading space.
-        val eventReader = factory.createXMLEventReader(new StringReader(xml))
-        val parser = factory.createFilteredReader(eventReader, filter)
         try {
+          xsdSchema.foreach { schema =>
+            schema.newValidator().validate(new StreamSource(new StringReader(xml)))
+          }
+
+          // It does not have to skip for white space, since `XmlInputFormat`
+          // always finds the root tag without a heading space.
+          val eventReader = factory.createXMLEventReader(new StringReader(xml))
+          val parser = factory.createFilteredReader(eventReader, filter)
+
           val rootEvent =
             StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
           val rootAttributes =

--- a/src/test/resources/basket.xml
+++ b/src/test/resources/basket.xml
@@ -1,0 +1,12 @@
+<baskets>
+  <basket>
+    <entry>
+      <key>9027</key>
+      <value>glasstop stove in black</value>
+    </entry>
+    <entry>
+      <key>288</key>
+      <value>wooden spoon</value>
+    </entry>
+  </basket>
+</baskets>

--- a/src/test/resources/basket.xsd
+++ b/src/test/resources/basket.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="basket">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="entry" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="key" minOccurs="0" type="xs:anyType"/>
+              <xs:element name="value" minOccurs="0" type="xs:anyType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/resources/basket_invalid.xml
+++ b/src/test/resources/basket_invalid.xml
@@ -1,0 +1,14 @@
+<baskets>
+  <basket>
+    <entry>
+      <key>9027</key>
+      <value>glasstop stove in black</value>
+      <extra>123</extra>
+    </entry>
+    <entry>
+      <key>288</key>
+      <value>wooden spoon</value>
+      <extra>123</extra>
+    </entry>
+  </basket>
+</baskets>


### PR DESCRIPTION
This adds a new configuration `rowValidationXSDPath`, which gives a path to an XSD file. If specified, this is used to validate the XML of each row. If validation fails, the row is considered 'corrupt' and handled as usual.

This does not affect the schema inferred by or specified for XML parsing. It can be used for finer-grained validation beyond simple schema checking.

See https://github.com/databricks/spark-xml/issues/224 for some discussion.

One open question is: is a path to a file the best API? support general URIs?
