### PR TITLE
Support Java 11 / test vs Spark 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
 sudo: false
 jdk: openjdk8
+scala:
+  - 2.12.10
 cache:
   directories:
     - $HOME/.ivy2
@@ -10,10 +12,11 @@ matrix:
         - 2.11.12
       env:
         - TEST_SPARK_VERSION="2.3.4"
-    - scala:
-        - 2.12.10
-      env:
+    - env:
         - TEST_SPARK_VERSION="2.4.4"
+    - jdk: openjdk11
+      env:
+        - TEST_SPARK_VERSION="3.0.0-preview"
 script:
   - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION clean scalastyle test:scalastyle mimaReportBinaryIssues coverage test coverageReport
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ autoScalaLibrary := false
 
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.6",
+  "org.glassfish.jaxb" % "txw2" % "2.3.2",
   "org.slf4j" % "slf4j-api" % "1.7.25" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test,
@@ -103,8 +104,9 @@ val ignoredABIProblems = {
       "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$" +
         "spark$xml$parsers$StaxXmlParser$$convertObject$default$4"),
     exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.util.CompressionCodecs.getCodecClass")
-
+      "com.databricks.spark.xml.util.CompressionCodecs.getCodecClass"),
+    exclude[IncompatibleMethTypeProblem](
+      "com.databricks.spark.xml.parsers.StaxXmlGenerator.apply")
   )
 }
 

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -15,9 +15,9 @@
  */
 package com.databricks.spark.xml.parsers
 
-import scala.collection.Map
+import javax.xml.stream.XMLStreamWriter
 
-import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
+import scala.collection.Map
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -35,7 +35,7 @@ private[xml] object StaxXmlGenerator {
     */
   def apply(
       schema: StructType,
-      writer: IndentingXMLStreamWriter,
+      writer: XMLStreamWriter,
       options: XmlOptions)(row: Row): Unit = {
     def writeChildElement(name: String, dt: DataType, v: Any): Unit = (name, dt, v) match {
       // If this is meant to be value but in no child, write only a value

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -22,7 +22,7 @@ import javax.xml.stream.XMLOutputFactory
 import scala.collection.Map
 
 import com.databricks.spark.xml.parsers.StaxXmlGenerator
-import com.sun.xml.internal.txw2.output.IndentingXMLStreamWriter
+import com.sun.xml.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.io.{Text, LongWritable}
 
 import org.apache.spark.rdd.RDD


### PR DESCRIPTION
This adds a test profile for Spark 3 and Java 11.
It switches to use the IndentingXMLStreamWriter from Glassfish instead of from the JDK, as it is no longer present in Java 9+.