### PR TITLE
Improve XSD validation: support files added via addFile(); cache Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ When reading files the API accepts several options:
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
 * `ignoreSurroundingSpaces`: Defines whether or not surrounding whitespaces from values being read should be skipped. Default is false.
-* `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. New in 0.8.0.
+* `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to 
+validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. 
+Note that if the same local path is not already also visible on the executors in the cluster, then the XSD and any others 
+it depends on should be added to the Spark executors with 
+[`SparkContext.addFile`](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext@addFile(path:String):Unit).
+In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`. New in 0.8.0.
 
 When writing files the API accepts several options:
 * `path`: Location to write files.

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -16,13 +16,10 @@
 package com.databricks.spark.xml.parsers
 
 import java.io.StringReader
-import java.nio.file.Paths
 
-import javax.xml.XMLConstants
 import javax.xml.stream.{EventFilter, XMLEventReader, XMLInputFactory, XMLStreamConstants}
 import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
 import javax.xml.transform.stream.StreamSource
-import javax.xml.validation.SchemaFactory
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConverters._
@@ -95,10 +92,7 @@ private[xml] object StaxXmlParser extends Serializable {
           }
       }
 
-      val xsdSchema = Option(options.rowValidationXSDPath).map { schemaFile =>
-        val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-        schemaFactory.newSchema(Paths.get(schemaFile).toFile)
-      }
+      val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
       iter.flatMap { xml =>
         try {

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -16,14 +16,11 @@
 package com.databricks.spark.xml.util
 
 import java.io.StringReader
-import java.nio.file.Paths
 import java.util.Comparator
 
-import javax.xml.XMLConstants
 import javax.xml.stream.{EventFilter, XMLEventReader, XMLInputFactory, XMLStreamConstants}
 import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
 import javax.xml.transform.stream.StreamSource
-import javax.xml.validation.SchemaFactory
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -97,10 +94,7 @@ private[xml] object InferSchema {
           }
       }
 
-      val xsdSchema = Option(options.rowValidationXSDPath).map { schemaFile =>
-        val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-        schemaFactory.newSchema(Paths.get(schemaFile).toFile)
-      }
+      val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
       iter.flatMap { xml =>
         try {

--- a/src/main/scala/com/databricks/spark/xml/util/ValidatorUtil.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/ValidatorUtil.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml.util
+
+import java.nio.file.Paths
+import javax.xml.validation.{Schema, SchemaFactory}
+import javax.xml.XMLConstants
+
+import com.google.common.cache.{CacheBuilder, CacheLoader}
+
+import org.apache.spark.SparkFiles
+
+/**
+ * Utilities for working with XSD validation.
+ */
+private[xml] object ValidatorUtil {
+
+  // Parsing XSDs may be slow, so cache them by path:
+
+  private val cache = CacheBuilder.newBuilder().softValues().build(
+    new CacheLoader[String, Schema] {
+      override def load(key: String): Schema = {
+        // Handle case where file exists as specified
+        var path = Paths.get(key)
+        if (!path.toFile.exists()) {
+          // Handle case where it was added with sc.addFile
+          path = Paths.get(SparkFiles.get(key))
+        }
+        val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+        schemaFactory.newSchema(path.toFile)
+      }
+    })
+
+  /**
+   * Parses the XSD at the given local path and caches it.
+   *
+   * @param path path to XSD
+   * @return Schema for the file at that path
+   */
+  def getSchema(path: String): Schema = cache.get(path)
+}

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1101,4 +1101,16 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(basketDF.select("_malformed_records").head().getString(0).startsWith("<basket>"))
   }
 
+  test("test XSD validation with addFile() with validation error") {
+    spark.sparkContext.addFile(basketXSD)
+    val basketDF = spark.read
+      .option("rowTag", "basket")
+      .option("inferSchema", true)
+      .option("rowValidationXSDPath", "basket.xsd")
+      .option("mode", "PERMISSIVE")
+      .option("columnNameOfCorruptRecord", "_malformed_records")
+      .xml(basketInvalid)
+    assert(basketDF.select("_malformed_records").head().getString(0).startsWith("<basket>"))
+  }
+
 }


### PR DESCRIPTION
(@HyukjinKwon only if you care to review, no big deal)

I found after adding the XSD validation feature that creating the XSD schema can be expensive. It can refer to lots of external resources that take time to download, and are accessed repeatedly. Further, I realized that the existing solution won't work unless the XSD itself is available on executors, unless the XSD is already on an accessible distributed store.

I'd propose to cache the Schema, firstly, to avoid recomputing it for inference vs parsing and for every partition. I've also made it support files added by SparkContext.addFile