### PR TITLE
Add spark.read.xml(xmlDataset: Dataset[String])

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -16,8 +16,8 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, SparkSession, SQLContext}
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset, SQLContext, SparkSession}
+import org.apache.spark.sql.types.StructType
 import com.databricks.spark.xml.util.XmlFile
 import com.databricks.spark.xml.util.FailFastMode
 
@@ -119,14 +119,11 @@ class XmlReader extends Serializable {
 
   /**
    * @param spark current SparkSession
-   * @param df XML for individual 'rows' as Strings
+   * @param ds XML for individual 'rows' as Strings
    * @return XML parsed as a DataFrame
    */
-  def xmlDataFrame(spark: SparkSession, df: DataFrame): DataFrame = {
-    require(df.columns.length == 1 && df.schema.fields.head.dataType == StringType,
-      "DataFrame must have a single String column containing XML")
-    import spark.implicits._
-    xmlRdd(spark, df.as[String].rdd)
+  def xmlDataset(spark: SparkSession, ds: Dataset[String]): DataFrame = {
+    xmlRdd(spark, ds.rdd)
   }
 
   /**

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -81,6 +81,11 @@ package object xml {
    */
   implicit class XmlDataFrameReader(reader: DataFrameReader) {
     def xml: String => DataFrame = reader.format("com.databricks.spark.xml").load
+
+    def xml(xmlDataset: Dataset[String]): DataFrame = {
+      val spark = SparkSession.builder.getOrCreate()
+      new XmlReader().xmlDataset(spark, xmlDataset)
+    }
   }
 
   /**


### PR DESCRIPTION
This change:

1. `def xmlDataset(spark: SparkSession, df: DataFrame):` -> `def xmlDataset(spark: SparkSession, ds: Dataset[String]):`
2. Adds a shortcut for it `spark.read.xml(xmlDataset: Dataset[String])`

This is similar with https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala#L506