### PR TITLE
from_xml and schema_for_xml support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         - TEST_SPARK_VERSION="2.4.4"
     - jdk: openjdk11
       env:
-        - TEST_SPARK_VERSION="3.0.0-preview"
+        - TEST_SPARK_VERSION="3.0.0-preview2"
 script:
   - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION clean scalastyle test:scalastyle mimaReportBinaryIssues coverage test coverageReport
 after_success:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ $SPARK_HOME/bin/spark-shell --packages com.databricks:spark-xml_2.12:0.7.0
 ```
 
 ## Features
+
 This package allows reading XML files in local or distributed filesystem as [Spark DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html).
+
 When reading files the API accepts several options:
+
 * `path`: Location of files. Similar to Spark can accept standard Hadoop globbing expressions.
 * `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
 * `samplingRatio`: Sampling ratio for inferring schema (0.0 ~ 1). Default is 1. Possible types are `StructType`, `ArrayType`, `StringType`, `LongType`, `DoubleType`, `BooleanType`, `TimestampType` and `NullType`, unless user provides a schema for this.
@@ -78,6 +81,7 @@ it depends on should be added to the Spark executors with
 In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`. New in 0.8.0.
 
 When writing files the API accepts several options:
+
 * `path`: Location to write files.
 * `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
 * `rootTag`: The root tag of your xml files to treat as the root. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `books`. Default is `ROWS`.
@@ -87,6 +91,20 @@ When writing files the API accepts several options:
 * `compression`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 
 Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml`.
+
+### Parsing Nested XML
+
+Although primarily used to convert (portions of) large XML documents into a DataFrame, from version 0.8.0 onwards,
+`spark-xml` can also parse XML in a string-valued column in an existing DataFrame with `from_xml`, in order to add
+it as a new column with parsed results as a struct.
+
+```scala
+import com.databricks.spark.xml.functions._
+import spark.implicits._
+val df = ... /// DataFrame with XML in column 'payload' 
+val payloadSchema = inferSchema(df.select("payload").as[String])
+val parsed = df.withColumn("decoded", from_xml(df.col("payload"), payloadSchema))
+``` 
 
 ## Structure Conversion
 

--- a/README.md
+++ b/README.md
@@ -94,17 +94,22 @@ Currently it supports the shortened name usage. You can use just `xml` instead o
 
 ### Parsing Nested XML
 
-Although primarily used to convert (portions of) large XML documents into a DataFrame, from version 0.8.0 onwards,
+Although primarily used to convert (portions of) large XML documents into a `DataFrame`, from version 0.8.0 onwards,
 `spark-xml` can also parse XML in a string-valued column in an existing DataFrame with `from_xml`, in order to add
 it as a new column with parsed results as a struct.
 
 ```scala
-import com.databricks.spark.xml.functions._
+import com.databricks.spark.xml.functions.from_xml
+import com.databricks.spark.xml.schema_of_xml
 import spark.implicits._
 val df = ... /// DataFrame with XML in column 'payload' 
 val payloadSchema = schema_of_xml(df.select("payload").as[String])
-val parsed = df.withColumn("decoded", from_xml(df.col("payload"), payloadSchema))
-``` 
+val parsed = df.withColumn("parsed", from_xml($"payload", payloadSchema))
+```
+
+- This can converts arrays of strings containing XML to arrays of parsed structs. Use `schema_of_xml_array` instead
+- `com.databricks.spark.xml.from_xml_string` is an alternative that operates on a String directly instead of a column,
+  for use in UDFsa
 
 ## Structure Conversion
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ it as a new column with parsed results as a struct.
 import com.databricks.spark.xml.functions._
 import spark.implicits._
 val df = ... /// DataFrame with XML in column 'payload' 
-val payloadSchema = inferSchema(df.select("payload").as[String])
+val payloadSchema = schema_of_xml(df.select("payload").as[String])
 val parsed = df.withColumn("decoded", from_xml(df.col("payload"), payloadSchema))
 ``` 
 

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,11 @@ val ignoredABIProblems = {
     exclude[DirectMissingMethodProblem](
       "com.databricks.spark.xml.util.CompressionCodecs.getCodecClass"),
     exclude[IncompatibleMethTypeProblem](
-      "com.databricks.spark.xml.parsers.StaxXmlGenerator.apply")
+      "com.databricks.spark.xml.parsers.StaxXmlGenerator.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$3$1"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$2$1")
   )
 }
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -65,7 +65,7 @@ This file is divided into 3 sections:
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-    <parameters><parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter></parameters>
+    <parameters><parameter name="regex"><![CDATA[^[A-Za-z]+$]]></parameter></parameters>
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">

--- a/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
@@ -35,7 +35,7 @@ case class XmlDataToCatalyst(
 
   @transient
   private lazy val factory: XMLInputFactory = StaxXmlParserUtils.buildFactory()
-  
+
   override lazy val dataType: DataType = schema
 
   override def checkInputDataTypes(): TypeCheckResult = schema match {

--- a/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml
+
+import javax.xml.stream.XMLInputFactory
+
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, UnaryExpression}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+import com.databricks.spark.xml.parsers.{StaxXmlParser, StaxXmlParserUtils}
+
+case class XmlDataToCatalyst(
+    child: Expression,
+    schema: StructType,
+    options: XmlOptions)
+  extends UnaryExpression with CodegenFallback with ExpectsInputTypes {
+
+  @transient
+  private lazy val factory: XMLInputFactory = StaxXmlParserUtils.buildFactory()
+  
+  override lazy val dataType: DataType = schema
+
+  override def checkInputDataTypes(): TypeCheckResult = schema match {
+    case _: StructType =>
+      super.checkInputDataTypes()
+    case _ => TypeCheckResult.TypeCheckFailure(
+      s"Input schema ${schema.simpleString} must be a struct or an array of structs.")
+  }
+
+  override def nullSafeEval(xml: Any): Any = xml match {
+    case string: UTF8String =>
+      CatalystTypeConverters.convertToCatalyst(
+        StaxXmlParser.parseColumn(string.toString, schema, factory, options))
+    case string: String =>
+      StaxXmlParser.parseColumn(string.toString, schema, factory, options)
+    case _ => null
+  }
+
+  override def inputTypes: Seq[DataType] = StringType :: Nil
+}

--- a/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
@@ -17,9 +17,9 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, UnaryExpression}
+import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -27,27 +27,34 @@ import com.databricks.spark.xml.parsers.StaxXmlParser
 
 case class XmlDataToCatalyst(
     child: Expression,
-    schema: StructType,
+    schema: DataType,
     options: XmlOptions)
   extends UnaryExpression with CodegenFallback with ExpectsInputTypes {
 
   override lazy val dataType: DataType = schema
 
-  override def checkInputDataTypes(): TypeCheckResult = schema match {
-    case _: StructType =>
-      super.checkInputDataTypes()
-    case _ => TypeCheckResult.TypeCheckFailure(
-      s"Input schema ${schema.simpleString} must be a struct or an array of structs.")
+  @transient
+  lazy val rowSchema: StructType = schema match {
+    case st: StructType => st
+    case ArrayType(st: StructType, _) => st
   }
 
   override def nullSafeEval(xml: Any): Any = xml match {
     case string: UTF8String =>
       CatalystTypeConverters.convertToCatalyst(
-        StaxXmlParser.parseColumn(string.toString, schema, options))
+        StaxXmlParser.parseColumn(string.toString, rowSchema, options))
     case string: String =>
-      StaxXmlParser.parseColumn(string.toString, schema, options)
+      StaxXmlParser.parseColumn(string.toString, rowSchema, options)
+    case arr: GenericArrayData =>
+      CatalystTypeConverters.convertToCatalyst(
+        arr.array.map(s => StaxXmlParser.parseColumn(s.toString, rowSchema, options)))
+    case arr: Array[_] =>
+      arr.map(s => StaxXmlParser.parseColumn(s.toString, rowSchema, options))
     case _ => null
   }
 
-  override def inputTypes: Seq[DataType] = StringType :: Nil
+  override def inputTypes: Seq[DataType] = schema match {
+    case _: StructType => Seq(StringType)
+    case ArrayType(_: StructType, _) => Seq(ArrayType(StringType))
+  }
 }

--- a/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
@@ -16,8 +16,6 @@
 
 package com.databricks.spark.xml
 
-import javax.xml.stream.XMLInputFactory
-
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -25,16 +23,13 @@ import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression,
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import com.databricks.spark.xml.parsers.{StaxXmlParser, StaxXmlParserUtils}
+import com.databricks.spark.xml.parsers.StaxXmlParser
 
 case class XmlDataToCatalyst(
     child: Expression,
     schema: StructType,
     options: XmlOptions)
   extends UnaryExpression with CodegenFallback with ExpectsInputTypes {
-
-  @transient
-  private lazy val factory: XMLInputFactory = StaxXmlParserUtils.buildFactory()
 
   override lazy val dataType: DataType = schema
 
@@ -48,9 +43,9 @@ case class XmlDataToCatalyst(
   override def nullSafeEval(xml: Any): Any = xml match {
     case string: UTF8String =>
       CatalystTypeConverters.convertToCatalyst(
-        StaxXmlParser.parseColumn(string.toString, schema, factory, options))
+        StaxXmlParser.parseColumn(string.toString, schema, options))
     case string: String =>
-      StaxXmlParser.parseColumn(string.toString, schema, factory, options)
+      StaxXmlParser.parseColumn(string.toString, schema, options)
     case _ => null
   }
 

--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -36,7 +36,7 @@ object functions {
    */
   @Experimental
   def schema_of_xml(ds: Dataset[String]): StructType =
-    inferSchema(ds, Map.empty[String, String])
+    schema_of_xml(ds, Map.empty[String, String])
 
   /**
    * Infers the schema of XML documents as strings.

--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -35,7 +35,7 @@ object functions {
    * @return inferred schema for XML
    */
   @Experimental
-  def inferSchema(ds: Dataset[String]): StructType =
+  def schema_of_xml(ds: Dataset[String]): StructType =
     inferSchema(ds, Map.empty[String, String])
 
   /**
@@ -46,7 +46,7 @@ object functions {
    * @return inferred schema for XML
    */
   @Experimental
-  def inferSchema(ds: Dataset[String], options: Map[String, String]): StructType =
+  def schema_of_xml(ds: Dataset[String], options: Map[String, String]): StructType =
     InferSchema.infer(ds.rdd, XmlOptions(options))
 
   /**

--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -17,40 +17,14 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.sql.{Column, Dataset, Row}
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
-
-import com.databricks.spark.xml.parsers.StaxXmlParser
-import com.databricks.spark.xml.util.InferSchema
+import org.apache.spark.sql.types.DataType
 
 /**
  * Support functions for working with XML columns directly.
  */
 object functions {
-
-  /**
-   * Infers the schema of XML documents as strings.
-   *
-   * @param ds Dataset of XML strings
-   * @param options additional XML parsing options
-   * @return inferred schema for XML
-   */
-  @Experimental
-  def schema_of_xml(ds: Dataset[String], options: Map[String, String] = Map.empty): StructType =
-    InferSchema.infer(ds.rdd, XmlOptions(options))
-
-  /**
-   * Infers the schema of XML documents when inputs are arrays of strings, each an XML doc.
-   *
-   * @param ds Dataset of XML strings
-   * @param options additional XML parsing options
-   * @return inferred schema for XML. Will be an ArrayType[StructType].
-   */
-  @Experimental
-  def schema_of_xml_array(ds: Dataset[Array[String]],
-      options: Map[String, String] = Map.empty): ArrayType =
-    ArrayType(InferSchema.infer(ds.rdd.flatMap(a => a), XmlOptions(options)))
 
   /**
    * Parses a column containing a XML string into a `StructType` with the specified schema.
@@ -64,18 +38,6 @@ object functions {
   def from_xml(e: Column, schema: DataType, options: Map[String, String] = Map.empty): Column = {
     val expr = CatalystSqlParser.parseExpression(e.toString())
     new Column(XmlDataToCatalyst(expr, schema, XmlOptions(options)))
-  }
-
-  /**
-   * @param xml XML document to parse, as string
-   * @param schema the schema to use when parsing the XML string
-   * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
-   * @return [[Row]] representing the parsed XML structure
-   */
-  @Experimental
-  def from_xml_string(xml: String, schema: StructType,
-       options: Map[String, String] = Map.empty): Row = {
-    StaxXmlParser.parseColumn(xml, schema, XmlOptions(options))
   }
 
 }

--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.{Column, Dataset}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.types.StructType
+
+import com.databricks.spark.xml.util.InferSchema
+
+/**
+ * Support functions for working with XML columns directly.
+ */
+object functions {
+
+  /**
+   * Infers the schema of XML documents as strings.
+   *
+   * @param ds Dataset of XML strings
+   * @return inferred schema for XML
+   */
+  @Experimental
+  def inferSchema(ds: Dataset[String]): StructType =
+    inferSchema(ds, Map.empty[String, String])
+
+  /**
+   * Infers the schema of XML documents as strings.
+   *
+   * @param ds Dataset of XML strings
+   * @param options additional XML parsing options
+   * @return inferred schema for XML
+   */
+  @Experimental
+  def inferSchema(ds: Dataset[String], options: Map[String, String]): StructType =
+    InferSchema.infer(ds.rdd, XmlOptions(options))
+
+  /**
+   * Parses a column containing a XML string into a `StructType` with the specified schema.
+   *
+   * @param e a string column containing XML data
+   * @param schema the schema to use when parsing the XML string
+   */
+  @Experimental
+  def from_xml(e: Column, schema: StructType): Column =
+    from_xml(e, schema, Map.empty)
+
+  /**
+   * Parses a column containing a XML string into a `StructType` with the specified schema.
+   *
+   * @param e a string column containing XML data
+   * @param schema the schema to use when parsing the XML string
+   * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
+   */
+  @Experimental
+  def from_xml(e: Column, schema: StructType, options: Map[String, String]): Column = {
+    val expr = CatalystSqlParser.parseExpression(e.toString())
+    new Column(XmlDataToCatalyst(expr, schema, XmlOptions(options)))
+  }
+
+}

--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -57,7 +57,7 @@ object functions {
    *
    * @param e a string column containing XML data
    * @param schema the schema to use when parsing the XML string. Must be a StructType if
-   *   column is string-valued, or ArrayType[StructType] if column is an array of strings 
+   *   column is string-valued, or ArrayType[StructType] if column is an array of strings
    * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
    */
   @Experimental

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -66,7 +66,7 @@ package object xml {
   implicit class XmlSchemaRDD(dataFrame: DataFrame) {
     @deprecated("Use write.format(\"xml\") or write.xml", "0.4.0")
     def saveAsXmlFile(
-        path: String, parameters: Map[String, String] = Map(),
+        path: String, parameters: scala.collection.Map[String, String] = Map(),
         compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
       val mutableParams = collection.mutable.Map(parameters.toSeq: _*)
       val safeCodec = mutableParams.get("codec")

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -20,11 +20,9 @@ import scala.collection.Map
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql._
-
 import com.databricks.spark.xml.util.XmlFile
 
 package object xml {
-
   /**
    * Adds a method, `xmlFile`, to [[SQLContext]] that allows reading XML data.
    */

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -19,63 +19,11 @@ import scala.collection.Map
 
 import org.apache.hadoop.io.compress.CompressionCodec
 
-import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.types.StructType
 
-import com.databricks.spark.xml.util.{InferSchema, XmlFile}
+import com.databricks.spark.xml.util.XmlFile
 
 package object xml {
-
-  private def withExpr(expr: Expression): Column = new Column(expr)
-
-  /**
-   * Infers the schema of XML documents as strings.
-   *
-   * @param ds Dataset of XML strings
-   * @return inferred schema for XML
-   */
-  @Experimental
-  def inferSchema(ds: Dataset[String]): StructType =
-    inferSchema(ds, Map.empty[String, String])
-
-  /**
-   * Infers the schema of XML documents as strings.
-   *
-   * @param ds Dataset of XML strings
-   * @param options additional XML parsing options
-   * @return inferred schema for XML
-   */
-  @Experimental
-  def inferSchema(ds: Dataset[String], options: Map[String, String]): StructType =
-    InferSchema.infer(ds.rdd, XmlOptions(options.toMap))
-
-  /**
-   * Parses a column containing a XML string into a `StructType` with the specified schema.
-   *
-   * @param e a string column containing XML data
-   * @param schema the schema to use when parsing the XML string
-   */
-  @Experimental
-  implicit def from_xml(e: Column, schema: StructType): Column =
-    from_xml(e, schema, Map.empty[String, String])
-
-  /**
-   * Parses a column containing a XML string into a `StructType` with the specified schema.
-   *
-   * @param e a string column containing XML data
-   * @param schema the schema to use when parsing the XML string
-   * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
-   */
-  @Experimental
-  implicit def from_xml(e: Column, schema: StructType, options: Map[String, String]): Column =
-    withExpr {
-      val map = options + ("isFunction" -> "true")
-      val expr = CatalystSqlParser.parseExpression(e.toString())
-      XmlDataToCatalyst(expr, schema, XmlOptions(map.toMap))
-    }
 
   /**
    * Adds a method, `xmlFile`, to [[SQLContext]] that allows reading XML data.

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -15,12 +15,14 @@
  */
 package com.databricks.spark
 
-import scala.collection.Map
-
 import org.apache.hadoop.io.compress.CompressionCodec
 
+import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
-import com.databricks.spark.xml.util.XmlFile
+import org.apache.spark.sql.types.{ArrayType, StructType}
+
+import com.databricks.spark.xml.parsers.StaxXmlParser
+import com.databricks.spark.xml.util.{InferSchema, XmlFile}
 
 package object xml {
   /**
@@ -111,4 +113,40 @@ package object xml {
     // Namely, roundtrip in writing and reading can end up in different schema structure.
     def xml: String => Unit = writer.format("com.databricks.spark.xml").save
   }
+
+  /**
+   * Infers the schema of XML documents as strings.
+   *
+   * @param ds Dataset of XML strings
+   * @param options additional XML parsing options
+   * @return inferred schema for XML
+   */
+  @Experimental
+  def schema_of_xml(ds: Dataset[String], options: Map[String, String] = Map.empty): StructType =
+    InferSchema.infer(ds.rdd, XmlOptions(options))
+
+  /**
+   * Infers the schema of XML documents when inputs are arrays of strings, each an XML doc.
+   *
+   * @param ds Dataset of XML strings
+   * @param options additional XML parsing options
+   * @return inferred schema for XML. Will be an ArrayType[StructType].
+   */
+  @Experimental
+  def schema_of_xml_array(ds: Dataset[Array[String]],
+                          options: Map[String, String] = Map.empty): ArrayType =
+    ArrayType(InferSchema.infer(ds.rdd.flatMap(a => a), XmlOptions(options)))
+
+  /**
+   * @param xml XML document to parse, as string
+   * @param schema the schema to use when parsing the XML string
+   * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
+   * @return [[Row]] representing the parsed XML structure
+   */
+  @Experimental
+  def from_xml_string(xml: String, schema: StructType,
+                      options: Map[String, String] = Map.empty): Row = {
+    StaxXmlParser.parseColumn(xml, schema, XmlOptions(options))
+  }
+
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -47,7 +47,6 @@ private[xml] object StaxXmlParser extends Serializable {
       options: XmlOptions): RDD[Row] = {
 
     xml.mapPartitions { iter =>
-      val factory = StaxXmlParserUtils.buildFactory()
       val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
       iter.flatMap { xml =>
@@ -56,7 +55,7 @@ private[xml] object StaxXmlParser extends Serializable {
             schema.newValidator().validate(new StreamSource(new StringReader(xml)))
           }
 
-          val parser = StaxXmlParserUtils.filteredReader(xml, factory)
+          val parser = StaxXmlParserUtils.filteredReader(xml)
           val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
           Some(convertObject(parser, schema, options, rootAttributes))
             .orElse(failedRecord(xml, options, schema))
@@ -70,10 +69,9 @@ private[xml] object StaxXmlParser extends Serializable {
     }
   }
 
-  def parseColumn(xml: String, schema: StructType, factory: XMLInputFactory,
-      options: XmlOptions): Row = {
+  def parseColumn(xml: String, schema: StructType, options: XmlOptions): Row = {
     try {
-      val parser = StaxXmlParserUtils.filteredReader(xml, factory)
+      val parser = StaxXmlParserUtils.filteredReader(xml)
       val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
       convertObject(parser, schema, options, rootAttributes)
     } catch {

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -27,14 +27,14 @@ import com.databricks.spark.xml.XmlOptions
 
 private[xml] object StaxXmlParserUtils {
 
-  def buildFactory(): XMLInputFactory = {
+  private val factory: XMLInputFactory = {
     val factory = XMLInputFactory.newInstance()
     factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
     factory.setProperty(XMLInputFactory.IS_COALESCING, true)
     factory
   }
 
-  def filteredReader(xml: String, factory: XMLInputFactory): XMLEventReader = {
+  def filteredReader(xml: String): XMLEventReader = {
     val filter = new EventFilter {
       override def accept(event: XMLEvent): Boolean =
         // Ignore comments and processing instructions

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -26,14 +26,14 @@ import scala.collection.JavaConverters._
 import com.databricks.spark.xml.XmlOptions
 
 private[xml] object StaxXmlParserUtils {
-  
+
   def buildFactory(): XMLInputFactory = {
     val factory = XMLInputFactory.newInstance()
     factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
     factory.setProperty(XMLInputFactory.IS_COALESCING, true)
     factory
   }
-  
+
   def filteredReader(xml: String, factory: XMLInputFactory): XMLEventReader = {
     val filter = new EventFilter {
       override def accept(event: XMLEvent): Boolean =
@@ -48,13 +48,13 @@ private[xml] object StaxXmlParserUtils {
     val eventReader = factory.createXMLEventReader(new StringReader(xml))
     factory.createFilteredReader(eventReader, filter)
   }
-  
+
   def gatherRootAttributes(parser: XMLEventReader): Array[Attribute] = {
     val rootEvent =
       StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
     rootEvent.asStartElement.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
   }
-  
+
   /**
    * Skips elements until this meets the given type of a element
    */

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -82,7 +82,6 @@ private[xml] object InferSchema {
     }
     // perform schema inference on each row and merge afterwards
     val rootType = schemaData.mapPartitions { iter =>
-      val factory = StaxXmlParserUtils.buildFactory()
       val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
       iter.flatMap { xml =>
@@ -91,7 +90,7 @@ private[xml] object InferSchema {
             schema.newValidator().validate(new StreamSource(new StringReader(xml)))
           }
 
-          val parser = StaxXmlParserUtils.filteredReader(xml, factory)
+          val parser = StaxXmlParserUtils.filteredReader(xml)
           val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
           Some(inferObject(parser, options, rootAttributes))
         } catch {

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.xml.util
 import java.io.StringReader
 import java.util.Comparator
 
-import javax.xml.stream.{EventFilter, XMLEventReader, XMLInputFactory, XMLStreamConstants}
+import javax.xml.stream.XMLEventReader
 import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
 import javax.xml.transform.stream.StreamSource
 
@@ -82,18 +82,7 @@ private[xml] object InferSchema {
     }
     // perform schema inference on each row and merge afterwards
     val rootType = schemaData.mapPartitions { iter =>
-      val factory = XMLInputFactory.newInstance()
-      factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
-      factory.setProperty(XMLInputFactory.IS_COALESCING, true)
-      val filter = new EventFilter {
-        override def accept(event: XMLEvent): Boolean =
-          // Ignore comments and processing instructions
-          event.getEventType match {
-            case XMLStreamConstants.COMMENT | XMLStreamConstants.PROCESSING_INSTRUCTION => false
-            case _ => true
-          }
-      }
-
+      val factory = StaxXmlParserUtils.buildFactory()
       val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
       iter.flatMap { xml =>
@@ -102,16 +91,8 @@ private[xml] object InferSchema {
             schema.newValidator().validate(new StreamSource(new StringReader(xml)))
           }
 
-          // It does not have to skip for white space, since `XmlInputFormat`
-          // always finds the root tag without a heading space.
-          val eventReader = factory.createXMLEventReader(new StringReader(xml))
-          val parser = factory.createFilteredReader(eventReader, filter)
-
-          val rootEvent =
-            StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT)
-          val rootAttributes =
-            rootEvent.asStartElement.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
-
+          val parser = StaxXmlParserUtils.filteredReader(xml, factory)
+          val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
           Some(inferObject(parser, options, rootAttributes))
         } catch {
           case NonFatal(_) if options.parseMode == PermissiveMode =>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1146,7 +1146,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
        """.stripMargin
     import spark.implicits._
     val df = spark.createDataFrame(Seq((8, xmlData))).toDF("number", "payload")
-    val xmlSchema = inferSchema(df.select("payload").as[String])
+    val xmlSchema = schema_of_xml(df.select("payload").as[String])
     val expectedSchema = df.schema.add("decoded", xmlSchema)
     val result = df.withColumn("decoded", from_xml(df.col("payload"), xmlSchema))
 
@@ -1164,7 +1164,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
        """.stripMargin
     import spark.implicits._
     val df = spark.createDataFrame(Seq((8, xmlData))).toDF("number", "payload")
-    val xmlSchema = inferSchema(df.select("payload").as[String])
+    val xmlSchema = schema_of_xml(df.select("payload").as[String])
     val result = df.withColumn("decoded", from_xml(df.col("payload"), xmlSchema))
     assert(result.select("decoded._corrupt_record").head().getString(0).nonEmpty)
   }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1169,4 +1169,20 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(result.select("decoded._corrupt_record").head().getString(0).nonEmpty)
   }
 
+  test("from_xml_string basic test") {
+    val xmlData =
+      """<parent foo="bar"><pid>14ft3</pid>
+        |  <name>dave guy</name>
+        |</parent>
+       """.stripMargin
+    import spark.implicits._
+    val df = spark.createDataFrame(Seq((8, xmlData))).toDF("number", "payload")
+    val xmlSchema = schema_of_xml(df.select("payload").as[String])
+    val result = from_xml_string(xmlData, xmlSchema)
+
+    assert(result.getString(0) === "bar")
+    assert(result.getString(1) === "dave guy")
+    assert(result.getString(2) === "14ft3")
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.databricks.spark.xml.XmlOptions._
+import com.databricks.spark.xml.functions._
 import com.databricks.spark.xml.util._
 
 import org.apache.spark.sql.types._

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1155,4 +1155,18 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(result.select("decoded._foo").head().getString(0) === "bar")
   }
 
+  test("from_xml error test") {
+    // XML contains error
+    val xmlData =
+      """<parent foo="bar"><pid>14ft3
+        |  <name>dave guy</name>
+        |</parent>
+       """.stripMargin
+    import spark.implicits._
+    val df = spark.createDataFrame(Seq((8, xmlData))).toDF("number", "payload")
+    val xmlSchema = inferSchema(df.select("payload").as[String])
+    val result = df.withColumn("decoded", from_xml(df.col("payload"), xmlSchema))
+    assert(result.select("decoded._corrupt_record").head().getString(0).nonEmpty)
+  }
+
 }


### PR DESCRIPTION
This is a continuation of https://github.com/databricks/spark-xml/pull/334/

This implements a `from_xml` expression that can turn an XML string column into a parsed structured column. It also opens up `inferSchema` for a `Dataset[String]` as a necessary support function.

The rest is really mild refactoring.