### PR TITLE
Add XSD validation to from_xml. Clarify semantics of parse mode for from_xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ val parsed = df.withColumn("parsed", from_xml($"payload", payloadSchema))
 
 - This can converts arrays of strings containing XML to arrays of parsed structs. Use `schema_of_xml_array` instead
 - `com.databricks.spark.xml.from_xml_string` is an alternative that operates on a String directly instead of a column,
-  for use in UDFsa
+  for use in UDFs
+- If you use `DROPMALFORMED` mode with `from_xml`, then XML values that do not parse correctly will result in a
+  `null` value for the column. No rows will be dropped.
+- If you use `PERMISSIVE` mode with `from_xml` et al, which is the default, then the parse mode will actually
+  instead default to `DROPMALFORMED`.
+  If however you include a column in the schema for `from_xml` that matches the `columnNameOfCorruptRecord`, then
+  `PERMISSIVE` mode will still output malformed records to that column in the resulting struct. 
 
 ## Structure Conversion
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,33 +86,11 @@ mimaPreviousArtifacts := Set("com.databricks" %% "spark-xml" % "0.8.0")
 
 val ignoredABIProblems = {
   import com.typesafe.tools.mima.core._
-  import com.typesafe.tools.mima.core.ProblemFilters._
   Seq(
-    exclude[IncompatibleResultTypeProblem](
-      "com.databricks.spark.xml.XmlOptions.DEFAULT_NULL_VALUE"),
-    exclude[MissingClassProblem]("com.databricks.spark.xml.DefaultSource15"),
-    exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.util.XmlFile.DEFAULT_ROW_SEPARATOR"),
-    exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.util.InferSchema.findTightestCommonTypeOfTwo"),
-    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlOptions.dropMalformed"),
-    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlOptions.permissive"),
-    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlOptions.failFast"),
-    exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes"),
-    exclude[MissingClassProblem]("com.databricks.spark.xml.util.ParseModes$"),
-    exclude[MissingTypesProblem]("com.databricks.spark.xml.XmlRelation"),
-    exclude[DirectMissingMethodProblem]("com.databricks.spark.xml.XmlRelation.buildScan"),
-    exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$" +
-        "spark$xml$parsers$StaxXmlParser$$convertObject$default$4"),
-    exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.util.CompressionCodecs.getCodecClass"),
-    exclude[IncompatibleMethTypeProblem](
-      "com.databricks.spark.xml.parsers.StaxXmlGenerator.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$3$1"),
+      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$5"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$2$1")
+      "com.databricks.spark.xml.parsers.StaxXmlParser.com$databricks$spark$xml$parsers$StaxXmlParser$$failedRecord$default$4")
   )
 }
 

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -70,7 +70,7 @@ private[xml] object StaxXmlParser extends Serializable {
     val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
     doParseColumn(xml, schema, options, parseMode, xsdSchema).orNull
   }
-  
+
   private def doParseColumn(xml: String,
       schema: StructType,
       options: XmlOptions,

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -17,9 +17,10 @@ package com.databricks.spark.xml.parsers
 
 import java.io.StringReader
 
-import javax.xml.stream.{XMLEventReader, XMLInputFactory}
+import javax.xml.stream.XMLEventReader
 import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
 import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.Schema
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConverters._
@@ -45,51 +46,60 @@ private[xml] object StaxXmlParser extends Serializable {
       xml: RDD[String],
       schema: StructType,
       options: XmlOptions): RDD[Row] = {
-
     xml.mapPartitions { iter =>
       val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
-
       iter.flatMap { xml =>
-        try {
-          xsdSchema.foreach { schema =>
-            schema.newValidator().validate(new StreamSource(new StringReader(xml)))
-          }
-
-          val parser = StaxXmlParserUtils.filteredReader(xml)
-          val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
-          Some(convertObject(parser, schema, options, rootAttributes))
-            .orElse(failedRecord(xml, options, schema))
-        } catch {
-          case e: PartialResultException =>
-            failedRecord(xml, options, schema, e.cause, Some(e.partialResult))
-          case NonFatal(e) =>
-            failedRecord(xml, options, schema, e)
-        }
+        doParseColumn(xml, schema, options, options.parseMode, xsdSchema)
       }
     }
   }
 
   def parseColumn(xml: String, schema: StructType, options: XmlOptions): Row = {
+    // The user=specified schema from from_xml, etc will typically not include a
+    // "corrupted record" column. In PERMISSIVE mode, which puts bad records in
+    // such a column, this would cause an error. In this mode, if such a column
+    // is not manually specified, then fall back to DROPMALFORMED, which will return
+    // null column values where parsing fails.
+    val parseMode =
+      if (options.parseMode == PermissiveMode &&
+          !schema.fields.exists(_.name == options.columnNameOfCorruptRecord)) {
+        DropMalformedMode
+      } else {
+        options.parseMode
+      }
+    val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
+    doParseColumn(xml, schema, options, parseMode, xsdSchema).orNull
+  }
+  
+  private def doParseColumn(xml: String,
+      schema: StructType,
+      options: XmlOptions,
+      parseMode: ParseMode,
+      xsdSchema: Option[Schema]): Option[Row] = {
     try {
+      xsdSchema.foreach { schema =>
+        schema.newValidator().validate(new StreamSource(new StringReader(xml)))
+      }
       val parser = StaxXmlParserUtils.filteredReader(xml)
       val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
-      convertObject(parser, schema, options, rootAttributes)
+      Some(convertObject(parser, schema, options, rootAttributes))
     } catch {
       case e: PartialResultException =>
-        // Null only if mode is DropMalformedMode
-        failedRecord(xml, options, schema, e.cause, Some(e.partialResult)).orNull
+        failedRecord(xml, options, parseMode, schema,
+          e.cause, Some(e.partialResult))
       case NonFatal(e) =>
-        failedRecord(xml, options, schema, e).orNull
+        failedRecord(xml, options, parseMode, schema, e)
     }
   }
 
   private def failedRecord(record: String,
       options: XmlOptions,
+      parseMode: ParseMode,
       schema: StructType,
       cause: Throwable = null,
       partialResult: Option[Row] = None): Option[Row] = {
     // create a row even if no corrupt record column is present
-    options.parseMode match {
+    parseMode match {
       case FailFastMode =>
         throw new IllegalArgumentException(
           s"Malformed line in FAILFAST mode: ${record.replaceAll("\n", "")}", cause)

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1199,7 +1199,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     assert(result.getString(1) === "dave guy")
     assert(result.getString(2) === "14ft3")
   }
-  
+
   test("from_xml with PERMISSIVE parse mode with no corrupt col schema") {
     // XML contains error
     val xmlData =


### PR DESCRIPTION
Add support for XSD validation (`rowValidationXSDPath`) when using functions like `from_xml`. 

Also, improve and clarify the semantics of parse mode when using `from_xml`. If the "corrupt record" column is not in the supplied schema, and parse mode is `PERMISSIVE`, then don't cause an error, but instead assume `DROPMALFORMED` mode, which results in a `null` value.

CC @HyukjinKwon purely FYI. No action needed.