### PR TITLE
extract to a method the inference of the xml schema

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -115,6 +115,17 @@ package object xml {
   }
 
   /**
+   * Infers the schema of an XML document as a string.
+   *
+   * @param s XML string
+   * @param options additional XML parsing options
+   * @return inferred schema for XML
+   */
+  @Experimental
+  def schema_of_xml_from_string(s: String, options: Map[String, String] = Map.empty): StructType =
+    InferSchema.infer(s, XmlOptions(options))
+
+  /**
    * Infers the schema of XML documents as strings.
    *
    * @param ds Dataset of XML strings

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -34,7 +34,7 @@ import com.databricks.spark.xml.util.TypeCast._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 
-object InferSchema {
+private[xml] object InferSchema {
 
   /**
    * Copied from internal Spark api
@@ -72,10 +72,11 @@ object InferSchema {
    * Infer the type of a xml string.
    * Useful for doing row by row schema inference
    */
-  def infer(xml: String, options: XmlOptions): Option[StructType] = {
+  def infer(xml: String, options: XmlOptions): StructType = {
     inferDataType(xml, options)
       .flatMap(canonicalizeType)
       .map(structTypeProjection)
+      .getOrElse(StructType(Seq()))
   }
 
   /**

--- a/src/test/resources/messages-bad.xml
+++ b/src/test/resources/messages-bad.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interchange>
+  <date>201903060708</date>
+  <message>
+    <id>1</id>
+    <sender>sender 1</sender>
+    <recipient>recipient 1</recipient>
+  </message>
+  <message>
+    <id>2</id>
+    <sender>sender 2</sender>
+    <recipient>recipient 2</recipient>
+  </message>
+  <message>
+    <id>3</id>
+    <sender>sender 3</sender>
+    <recipient>recipient 3</recipient>
+  </message>
+</interchange>

--- a/src/test/scala/com/databricks/spark/xml/util/InferSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/InferSchemaSuite.scala
@@ -1,0 +1,86 @@
+package com.databricks.spark.xml.util
+
+import com.databricks.spark.xml._
+import org.apache.spark.sql.types._
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkException
+import org.apache.spark.sql.functions.{explode, col}
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.rdd.RDD
+
+final class InferSchemaSuite extends FunSuite with BeforeAndAfterAll with Matchers {
+
+  private val schema = (new StructType)
+    .add("date", StringType, false)
+    .add("message",
+      ArrayType(
+        (new StructType)
+          .add("id", StringType, false)
+          .add("sender", StringType, false)
+          .add("recipient", StringType, false)
+          .add("address", StringType, false)
+          .add("content", StringType, false)
+          , false
+        )
+      , false
+    )
+
+  private val messages_bad_file = "src/test/resources/messages-bad.xml"
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark = SparkSession.builder
+      .master("local[2]")
+      .appName("TextFileSuite")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      spark.stop()
+      spark = null
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("load bad xml data should raise exception when action is executed") {
+    val messageDF = spark.read
+      .option("rowTag", "interchange")
+      .schema(schema)
+      .xml(messages_bad_file)
+
+    val df = messageDF
+      .select(explode(col("message")).as("message"))
+      .selectExpr("message.id as id", "message.sender as sender", "message.address as address")
+
+    an [SparkException] should be thrownBy df.count()
+  }
+
+  test("load bad xml data should return a empty RDD without raising exception") {
+    // In practice this is useful for reading messages from a directory with wholeTextFiles
+    // instead of a single file.
+    val messageRDD = spark.read.textFile(messages_bad_file).rdd
+
+    case class MatchSchema(
+      schema: StructType,
+      xmlOptions: Map[String, String] = Map.empty
+    ) {
+      // This function is complex so, I will leave it out. Just wanted to show the use case
+      // of infering the schema from a single XML document in a string
+      private def isSubset(left: StructType, right: StructType): Boolean = false
+
+      def filter(rdd: RDD[String]): RDD[String] = {
+        rdd.filter { s => isSubset(schema_of_xml_from_string(s), schema) }
+      }
+    }
+
+    // Filter out the bad files that don't fit the schema
+    val goodMessages = MatchSchema(schema).filter(messageRDD)
+
+    goodMessages.count() shouldEqual 0
+  }
+}


### PR DESCRIPTION
This change is intended to make available the functionality of inferring the schema of a xml String.
This allows to have a schema inference over a RDD row by row, using a UDF to map over the desired field. This field being a String containing the whole xml document.

In my case, I needed this functionality to check if the inferred schema from the data is a subset of the schema that I want to impose on it. Every file can have problems, so loading a whole directory of xml files into a DataFrame directly wouldn't allow me to discard the bad files.

