### PR TITLE
Handle case of whitespace-only, numeric-primitive field correctly

### DIFF
--- a/src/test/resources/whitespace_error.xml
+++ b/src/test/resources/whitespace_error.xml
@@ -1,0 +1,1 @@
+<Books><Book><Price> </Price></Book></Books>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1232,7 +1232,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val result = df.withColumn("decoded", from_xml(df.col("payload"), xmlSchema))
     assert(result.select("decoded").head().get(0) === null)
   }
-  
+
   test("double field encounters whitespace-only value") {
     val schema = buildSchema(struct("Book", field("Price", DoubleType)), field("_corrupt_record"))
     val whitespaceDF = spark.read

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -82,6 +82,7 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
   private val basketInvalid = resDir + "basket_invalid.xml"
   private val basketXSD = resDir + "basket.xsd"
   private val unclosedTag = resDir + "unclosed_tag.xml"
+  private val whitespaceError = resDir + "whitespace_error.xml"
 
   private val booksTag = "book"
   private val booksRootTag = "books"
@@ -1230,6 +1231,17 @@ final class XmlSuite extends FunSuite with BeforeAndAfterAll {
     val df = spark.createDataFrame(Seq((8, xmlData))).toDF("number", "payload")
     val result = df.withColumn("decoded", from_xml(df.col("payload"), xmlSchema))
     assert(result.select("decoded").head().get(0) === null)
+  }
+  
+  test("double field encounters whitespace-only value") {
+    val schema = buildSchema(struct("Book", field("Price", DoubleType)), field("_corrupt_record"))
+    val whitespaceDF = spark.read
+      .option("rowTag", "Books")
+      .schema(schema)
+      .xml(whitespaceError)
+
+    assert(whitespaceDF.count() === 1)
+    assert(whitespaceDF.take(1).head.getAs[String]("_corrupt_record") !== null)
   }
 
 }


### PR DESCRIPTION
Where a field has, say, type 'double', and the element value is just whitespace, it fails with a hard error instead of being a 'normal' parsing failure. See https://github.com/databricks/spark-xml/issues/446

This fixes it by actually trying to parse the whitespace as the desired type, to generate the normal failure. Otherwise the whitespace was returned to Spark as if it were a Double.