### PR TITLE
fix date and datetime parsing

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -83,7 +83,8 @@ object TypeCast {
   }
 
   val supportedXmlDateFormatters = List(
-    // '2011-12-03+01:00'; '2011-12-03'
+    // 2011-12-03
+    // 2011-12-03+01:00
     DateTimeFormatter.ISO_DATE
   )
 
@@ -102,7 +103,7 @@ object TypeCast {
   }
 
   val supportedXmlTimestampFormatters = List(
-    // "2002-05-30 21:46:54"
+    // 2002-05-30 21:46:54
     new DateTimeFormatterBuilder()
       .parseCaseInsensitive()
       .append(DateTimeFormatter.ISO_LOCAL_DATE)

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -18,9 +18,9 @@ package com.databricks.spark.xml.util
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
 import java.text.NumberFormat
-import java.util.Locale
-import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.util.Locale
 
 import scala.util.Try
 import scala.util.control.Exception._
@@ -64,14 +64,8 @@ object TypeCast {
           .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
         case _: BooleanType => parseXmlBoolean(datum)
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
-        case _: TimestampType => parseXmlTimestamp(List(
-            DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.of("UTC")),
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-            DateTimeFormatter.ISO_INSTANT
-          ), datum)
-        case _: DateType => parseXmlDate(List(
-            DateTimeFormatter.ISO_DATE
-          ), datum)
+        case _: TimestampType => parseXmlTimestamp(supportedXmlTimestampFormatters, datum)
+        case _: DateType => parseXmlDate(supportedXmlDateFormatters, datum)
         case _: StringType => datum
         case _ => throw new IllegalArgumentException(s"Unsupported type: ${castType.typeName}")
       }
@@ -88,6 +82,11 @@ object TypeCast {
     }
   }
 
+  val supportedXmlDateFormatters = List(
+    // '2011-12-03+01:00'; '2011-12-03'
+    DateTimeFormatter.ISO_DATE
+  )
+
   @scala.annotation.tailrec
   def parseXmlDate(formatters: List[DateTimeFormatter], value: String): Date = {
     formatters match {
@@ -101,6 +100,23 @@ object TypeCast {
         }
     }
   }
+
+  val supportedXmlTimestampFormatters = List(
+    // "2002-05-30 21:46:54"
+    new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .toFormatter()
+      .withZone(ZoneId.of("UTC")),
+    // 2002-05-30T21:46:54
+    DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.of("UTC")),
+    // 2002-05-30T21:46:54+06:00
+    DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+    // 2002-05-30T21:46:54.1234Z
+    DateTimeFormatter.ISO_INSTANT
+  )
 
   @scala.annotation.tailrec
   def parseXmlTimestamp(formatters: List[DateTimeFormatter], value: String): Timestamp = {

--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -71,7 +71,7 @@ object TypeCast {
           ), datum)
         case _: DateType => parseXmlDate(List(
             DateTimeFormatter.ISO_DATE
-          ), datum)        
+          ), datum)
         case _: StringType => datum
         case _ => throw new IllegalArgumentException(s"Unsupported type: ${castType.typeName}")
       }
@@ -100,7 +100,7 @@ object TypeCast {
             parseXmlDate(tail, value)
         }
     }
-  }  
+  }
 
   @scala.annotation.tailrec
   def parseXmlTimestamp(formatters: List[DateTimeFormatter], value: String): Timestamp = {

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -17,6 +17,7 @@ package com.databricks.spark.xml.util
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
+import java.time.{ZoneId, ZonedDateTime}
 import java.util.Locale
 
 import org.scalatest.FunSuite
@@ -71,10 +72,26 @@ final class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1", BooleanType, options) === true)
     assert(TypeCast.castTo("false", BooleanType, options) === false)
     assert(TypeCast.castTo("0", BooleanType, options) === false)
-    val timestamp = "2015-01-01 00:00:00"
-    assert(
-      TypeCast.castTo(timestamp, TimestampType, options) === Timestamp.valueOf(timestamp))
-    assert(TypeCast.castTo("2015-01-01", DateType, options) === Date.valueOf("2015-01-01"))
+    assert(TypeCast.castTo("2002-05-30T21:46:54", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54Z", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54-06:00", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("-06:00")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54+06:00", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("+06:00")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234Z", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234-06:00", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("-06:00")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234+06:00", TimestampType, options) === 
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("+06:00")).toInstant()))      
+    assert(TypeCast.castTo("2002-09-24", DateType, options) === Date.valueOf("2002-09-24"))
+    assert(TypeCast.castTo("2002-09-24Z", DateType, options) === Date.valueOf("2002-09-24"))
+    assert(TypeCast.castTo("2002-09-24-06:00", DateType, options) === Date.valueOf("2002-09-24"))
+    assert(TypeCast.castTo("2002-09-24+06:00", DateType, options) === Date.valueOf("2002-09-24"))
   }
 
   test("Types with sign are cast correctly") {

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -72,22 +72,24 @@ final class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1", BooleanType, options) === true)
     assert(TypeCast.castTo("false", BooleanType, options) === false)
     assert(TypeCast.castTo("0", BooleanType, options) === false)
-    assert(TypeCast.castTo("2002-05-30T21:46:54", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30 21:46:54", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54", TimestampType, options) ===
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54Z", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54Z", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54-06:00", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54-06:00", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("-06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54+06:00", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54+06:00", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("+06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234Z", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234Z", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234-06:00", TimestampType, options) === 
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234-06:00", TimestampType, options) ===
       Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("-06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234+06:00", TimestampType, options) === 
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("+06:00")).toInstant()))      
+    assert(TypeCast.castTo("2002-05-30T21:46:54.1234+06:00", TimestampType, options) ===
+      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("+06:00")).toInstant()))
     assert(TypeCast.castTo("2002-09-24", DateType, options) === Date.valueOf("2002-09-24"))
     assert(TypeCast.castTo("2002-09-24Z", DateType, options) === Date.valueOf("2002-09-24"))
     assert(TypeCast.castTo("2002-09-24-06:00", DateType, options) === Date.valueOf("2002-09-24"))

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -72,24 +72,69 @@ final class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("1", BooleanType, options) === true)
     assert(TypeCast.castTo("false", BooleanType, options) === false)
     assert(TypeCast.castTo("0", BooleanType, options) === false)
-    assert(TypeCast.castTo("2002-05-30 21:46:54", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54Z", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54-06:00", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("-06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54+06:00", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("+06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234Z", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234-06:00", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("-06:00")).toInstant()))
-    assert(TypeCast.castTo("2002-05-30T21:46:54.1234+06:00", TimestampType, options) ===
-      Timestamp.from(ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("+06:00")).toInstant()))
+    assert(
+      TypeCast.castTo("2002-05-30 21:46:54", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54.1234", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54Z", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("UTC"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54-06:00", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("-06:00"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54+06:00", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 0, ZoneId.of("+06:00"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54.1234Z", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("UTC"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54.1234-06:00", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("-06:00"))
+        .toInstant()
+      )
+    )
+    assert(
+      TypeCast.castTo("2002-05-30T21:46:54.1234+06:00", TimestampType, options) ===
+      Timestamp.from(
+        ZonedDateTime.of(2002, 5, 30, 21, 46, 54, 123400000, ZoneId.of("+06:00"))
+        .toInstant()
+      )
+    )
     assert(TypeCast.castTo("2002-09-24", DateType, options) === Date.valueOf("2002-09-24"))
     assert(TypeCast.castTo("2002-09-24Z", DateType, options) === Date.valueOf("2002-09-24"))
     assert(TypeCast.castTo("2002-09-24-06:00", DateType, options) === Date.valueOf("2002-09-24"))


### PR DESCRIPTION
Hi,
Currently the parsing of Date and Timestamp types does not comply with the the XSD schema definition: https://www.w3.org/TR/xmlschema-2/#dateTime

This PR adds the official date and datetime parsing when using a user-defined schema.