### PR TITLE
Minor cleanup, including deprecating unuseful withFailFast method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ credentials += Credentials(
   sys.env.getOrElse("USERNAME", ""),
   sys.env.getOrElse("PASSWORD", ""))
 
-resolvers += "GCS Maven Central mirror" at "https://maven-central.storage-download.googleapis.com/maven2/"
+resolvers +=
+  "GCS Maven Central mirror" at "https://maven-central.storage-download.googleapis.com/maven2/"
 
 parallelExecution in Test := false
 

--- a/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlDataToCatalyst.scala
@@ -44,7 +44,7 @@ case class XmlDataToCatalyst(
       CatalystTypeConverters.convertToCatalyst(
         StaxXmlParser.parseColumn(string.toString, rowSchema, options))
     case string: String =>
-      StaxXmlParser.parseColumn(string.toString, rowSchema, options)
+      StaxXmlParser.parseColumn(string, rowSchema, options)
     case arr: GenericArrayData =>
       CatalystTypeConverters.convertToCatalyst(
         arr.array.map(s => StaxXmlParser.parseColumn(s.toString, rowSchema, options)))

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -58,8 +58,13 @@ class XmlReader extends Serializable {
     this
   }
 
+  @deprecated("Use withParseMode(\"FAILFAST\") instead", "0.10.0")
   def withFailFast(failFast: Boolean): XmlReader = {
-    parameters += ("mode" -> FailFastMode.name)
+    if (failFast) {
+      parameters += ("mode" -> FailFastMode.name)
+    } else {
+      parameters -= "mode"
+    }
     this
   }
 

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -53,7 +53,7 @@ package object xml {
       val xmlRelation = XmlRelation(
         () => XmlFile.withCharset(sqlContext.sparkContext, filePath, charset, rowTag),
         location = Some(filePath),
-        parameters = parameters.toMap)(sqlContext)
+        parameters = parameters)(sqlContext)
       sqlContext.baseRelationToDataFrame(xmlRelation)
     }
   }
@@ -134,7 +134,7 @@ package object xml {
    */
   @Experimental
   def schema_of_xml_df(df: DataFrame, options: Map[String, String] = Map.empty): StructType =
-    schema_of_xml(df.as[String](Encoders.STRING), options);
+    schema_of_xml(df.as[String](Encoders.STRING), options)
 
   /**
    * Infers the schema of XML documents when inputs are arrays of strings, each an XML doc.

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -75,7 +75,7 @@ private[xml] object StaxXmlGenerator {
 
     def writeElement(dt: DataType, v: Any): Unit = (dt, v) match {
       case (_, null) | (NullType, _) => writer.writeCharacters(options.nullValue)
-      case (StringType, v: String) => writer.writeCharacters(v.toString)
+      case (StringType, v: String) => writer.writeCharacters(v)
       case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(v.toString)
       case (IntegerType, v: Int) => writer.writeCharacters(v.toString)
       case (ShortType, v: Short) => writer.writeCharacters(v.toString)

--- a/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
+++ b/src/test/java/com/databricks/spark/xml/JavaXmlSuite.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
 public final class JavaXmlSuite {
@@ -61,7 +62,7 @@ public final class JavaXmlSuite {
 
     @Test
     public void testXmlParser() {
-        Dataset df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(spark, booksFile);
+        Dataset<Row> df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(spark, booksFile);
         String prefix = XmlOptions.DEFAULT_ATTRIBUTE_PREFIX();
         long result = df.select(prefix + "id").count();
         Assert.assertEquals(result, numBooks);
@@ -71,7 +72,7 @@ public final class JavaXmlSuite {
     public void testLoad() {
         Map<String, String> options = new HashMap<>();
         options.put("rowTag", booksFileTag);
-        Dataset df = spark.read().options(options).format("xml").load(booksFile);
+        Dataset<Row> df = spark.read().options(options).format("xml").load(booksFile);
         long result = df.select("description").count();
         Assert.assertEquals(result, numBooks);
     }
@@ -80,10 +81,10 @@ public final class JavaXmlSuite {
     public void testSave() throws IOException {
         Path booksPath = getEmptyTempDir().resolve("booksFile");
 
-        Dataset df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(spark, booksFile);
+        Dataset<Row> df = (new XmlReader()).withRowTag(booksFileTag).xmlFile(spark, booksFile);
         df.select("price", "description").write().format("xml").save(booksPath.toString());
 
-        Dataset newDf = (new XmlReader()).xmlFile(spark, booksPath.toString());
+        Dataset<Row> newDf = (new XmlReader()).xmlFile(spark, booksPath.toString());
         long result = newDf.select("price").count();
         Assert.assertEquals(result, numBooks);
     }

--- a/src/test/scala/com/databricks/spark/xml/XmlPartitioningSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlPartitioningSuite.scala
@@ -15,12 +15,14 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Tests various cases of partition size, compression.
  */
-final class XmlPartitioningSuite extends FunSuite with Matchers with BeforeAndAfterAll {
+final class XmlPartitioningSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
   private def doPartitionTest(suffix: String, blockSize: Long, large: Boolean): Unit = {
     val spark = SparkSession.builder()

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -24,7 +24,8 @@ import scala.io.Source
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.io.compress.GzipCodec
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import com.databricks.spark.xml.XmlOptions._
 import com.databricks.spark.xml.functions._
@@ -34,7 +35,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.SparkException
 
-final class XmlSuite extends FunSuite with BeforeAndAfterAll {
+final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   private val resDir = "src/test/resources/"
   private val agesFile = resDir + "ages.xml"

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
@@ -21,11 +21,12 @@ import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
 
 import scala.collection.JavaConverters._
 
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import com.databricks.spark.xml.XmlOptions
 
-final class StaxXmlParserUtilsSuite extends FunSuite with BeforeAndAfterAll {
+final class StaxXmlParserUtilsSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   private val factory = XMLInputFactory.newInstance()
   factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)

--- a/src/test/scala/com/databricks/spark/xml/util/CompressionCodecsSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/CompressionCodecsSuite.scala
@@ -17,9 +17,9 @@ package com.databricks.spark.xml.util
 
 import org.apache.hadoop.io.compress._
 import org.apache.hadoop.util.VersionInfo
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-final class CompressionCodecsSuite extends FunSuite {
+final class CompressionCodecsSuite extends AnyFunSuite {
 
   test("Get classes of compression codecs") {
     assert(CompressionCodecs.getCodecClass(classOf[GzipCodec].getName) == classOf[GzipCodec])

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -20,12 +20,12 @@ import java.sql.{Date, Timestamp}
 import java.time.{ZoneId, ZonedDateTime}
 import java.util.Locale
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types._
 import com.databricks.spark.xml.XmlOptions
 
-final class TypeCastSuite extends FunSuite {
+final class TypeCastSuite extends AnyFunSuite {
 
   test("Can parse decimal type values") {
     val options = new XmlOptions()

--- a/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XmlFileSuite.scala
@@ -18,9 +18,10 @@ package com.databricks.spark.xml.util
 import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
 
 import org.apache.spark.SparkContext
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
-final class XmlFileSuite extends FunSuite with BeforeAndAfterAll {
+final class XmlFileSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   private val booksFile = "src/test/resources/books.xml"
   private val booksUnicodeInTagNameFile = "src/test/resources/books-unicode-in-tag-name.xml"


### PR DESCRIPTION
Very minor code cleanup to avoid warnings.

Deprecate `XmlReader.withFailFast`, as it doesn't so much make sense when there is already a method to set mode. Also, the method previously ignored its argument; now it will unset the property if passed `false`.