### PR TITLE
XSD -> schema tool with a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: scala
 jdk: openjdk8
+os: linux
+dist: bionic
 scala:
   - 2.12.10
 cache:
   directories:
     - $HOME/.ivy2
-matrix:
+jobs:
   include:
     - scala:
         - 2.11.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: scala
-sudo: false
 jdk: openjdk8
 scala:
   - 2.12.10

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ When writing files the API accepts several options:
 
 Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml`.
 
+### XSD Support
+
+Per above, the XML for individual rows can be validated against an XSD using `rowValidationXSDPath`.
+
+From 0.10 onwards, the utility `com.databricks.spark.xml.util.XSDToSchema` can be used to extract a Spark DataFrame
+schema from _some_ XSD files. It supports only simple, complex and sequence types, only basic XSD functionality,
+and is experimental.
+
+```scala
+import com.databricks.spark.xml.util.XSDToSchema
+import java.nio.file.Paths
+
+val schema = XSDToSchema.read(Paths.get("/path/to/your.xsd"))
+val df = spark.read.schema(schema)....xml(...)
+```
+
 ### Parsing Nested XML
 
 Although primarily used to convert (portions of) large XML documents into a `DataFrame`, from version 0.8.0 onwards,
@@ -116,7 +132,7 @@ val parsed = df.withColumn("parsed", from_xml($"payload", payloadSchema))
   instead default to `DROPMALFORMED`.
   If however you include a column in the schema for `from_xml` that matches the `columnNameOfCorruptRecord`, then
   `PERMISSIVE` mode will still output malformed records to that column in the resulting struct. 
-  
+
 #### Pyspark notes
 
 The functions above are exposed in the Scala API only, at the moment, as there is no separate Python package

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ autoScalaLibrary := false
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.6",
   "org.glassfish.jaxb" % "txw2" % "2.3.2",
+  "org.apache.ws.xmlschema" % "xmlschema-core" % "2.2.5",
   "org.slf4j" % "slf4j-api" % "1.7.25" % Provided,
   "org.scalatest" %% "scalatest" % "3.1.1" % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test,

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -102,6 +102,8 @@ object XSDToSchema {
                    Constants.XSD_UNSIGNEDSHORT => IntegerType
               case Constants.XSD_LONG |
                    Constants.XSD_UNSIGNEDINT => LongType
+              case Constants.XSD_DATE => DateType
+              case Constants.XSD_DATETIME => TimestampType
               case _ => StringType
             }
           case _ => StringType

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml.util
+
+import java.io.{File, FileInputStream, InputStreamReader, StringReader}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+import scala.collection.JavaConverters._
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.types._
+import org.apache.ws.commons.schema._
+import org.apache.ws.commons.schema.constants.Constants
+
+/**
+ * Utility to generate a Spark schema from an XSD. Not all XSD schemas are simple tabular schemas,
+ * so not all elements or XSDs are supported.
+ */
+@Experimental
+object XSDToSchema {
+
+  /**
+   * Reads a schema from an XSD file.
+   *
+   * @param xsdFile XSD file
+   * @return Spark-compatible schema
+   */
+  @Experimental
+  def read(xsdFile: File): StructType = {
+    val xmlSchema = new XmlSchemaCollection().read(
+      new InputStreamReader(new FileInputStream(xsdFile), StandardCharsets.UTF_8))
+    getStructType(xmlSchema)
+  }
+
+  /**
+   * Reads a schema from an XSD file.
+   *
+   * @param xsdFile XSD file
+   * @return Spark-compatible schema
+   */
+  @Experimental
+  def read(xsdFile: Path): StructType = read(xsdFile.toFile)
+
+  /**
+   * Reads a schema from an XSD as a string.
+   *
+   * @param xsdString XSD as a string
+   * @return Spark-compatible schema
+   */
+  @Experimental
+  def read(xsdString: String): StructType = {
+    val xmlSchema = new XmlSchemaCollection().read(new StringReader(xsdString))
+    getStructType(xmlSchema)
+  }
+
+
+  private def getStructField(xmlSchema: XmlSchema, schemaType: XmlSchemaType): StructField = {
+    schemaType match {
+      // xs:simpleType
+      case simpleType: XmlSchemaSimpleType =>
+        val baseName = "baseName"
+        simpleType.getContent match {
+          case restriction: XmlSchemaSimpleTypeRestriction =>
+            val matchType =
+              if (restriction.getBaseTypeName == Constants.XSD_ANYSIMPLETYPE) {
+                simpleType.getQName
+              } else {
+                restriction.getBaseTypeName
+              }
+            matchType match {
+              case Constants.XSD_BOOLEAN => StructField(baseName, BooleanType)
+              case Constants.XSD_BYTE => StructField(baseName, BinaryType)
+              case Constants.XSD_DATE |
+                   Constants.XSD_DATETIME |
+                   Constants.XSD_TIME =>
+                StructField(baseName, StringType)
+              case Constants.XSD_DECIMAL =>
+                val scale = restriction.getFacets.asScala.collectFirst {
+                  case facet: XmlSchemaFractionDigitsFacet => facet
+                }
+                scale match {
+                  case Some(scale) => StructField(
+                    baseName, DecimalType(38, scale.getValue.toString.toInt))
+                  case None => StructField(baseName, DecimalType(38, 18))
+                }
+              case Constants.XSD_DOUBLE => StructField(baseName, DoubleType)
+              case Constants.XSD_FLOAT => StructField(baseName, FloatType)
+              case Constants.XSD_INTEGER |
+                   Constants.XSD_SHORT |
+                   Constants.XSD_NEGATIVEINTEGER |
+                   Constants.XSD_NONNEGATIVEINTEGER |
+                   Constants.XSD_NONPOSITIVEINTEGER |
+                   Constants.XSD_POSITIVEINTEGER |
+                   Constants.XSD_UNSIGNEDINT |
+                   Constants.XSD_UNSIGNEDLONG |
+                   Constants.XSD_UNSIGNEDSHORT =>
+                StructField(baseName, IntegerType)
+              case Constants.XSD_LONG => StructField(baseName, LongType)
+              case Constants.XSD_STRING |
+                   Constants.XSD_BASE64 |
+                   Constants.XSD_ANYTYPE =>
+                StructField(baseName, StringType)
+            }
+          case _ => StructField(baseName, StringType)
+        }
+      // xs:complexType
+      case complexType: XmlSchemaComplexType =>
+        complexType.getContentModel match {
+          case content: XmlSchemaSimpleContent =>
+            // xs:simpleContent
+            content.getContent match {
+              case extension: XmlSchemaSimpleContentExtension =>
+                val baseStructField = getStructField(xmlSchema,
+                  xmlSchema.getTypeByName(extension.getBaseTypeName))
+                val value = StructField("_VALUE", baseStructField.dataType)
+                val attributes = extension.getAttributes.asScala.map {
+                  case attribute: XmlSchemaAttribute =>
+                    val baseStructField = getStructField(xmlSchema,
+                      xmlSchema.getTypeByName(attribute.getSchemaTypeName))
+                    StructField(s"_${attribute.getName}", baseStructField.dataType)
+                }
+                StructField(complexType.getName, StructType(value +: attributes))
+            }
+          case null =>
+            complexType.getParticle match {
+              // xs:all
+              case all: XmlSchemaAll =>
+                val fields = all.getItems.asScala.map {
+                  case element: XmlSchemaElement =>
+                    val baseStructField = getStructField(xmlSchema, element.getSchemaType)
+                    val field = StructField(element.getName, baseStructField.dataType)
+                    if (element.getMaxOccurs == 1) {
+                      field
+                    } else {
+                      StructField(element.getName, ArrayType(field.dataType))
+                    }
+                }
+                StructField(complexType.getName, StructType(fields))
+              // xs:choice
+              case choice: XmlSchemaChoice =>
+                val fields = choice.getItems.asScala.map { case element: XmlSchemaElement =>
+                  val baseStructField = getStructField(xmlSchema, element.getSchemaType)
+                  val field = StructField(element.getName, baseStructField.dataType)
+                  if (element.getMaxOccurs == 1) {
+                    field
+                  } else {
+                    StructField(element.getName, ArrayType(field.dataType))
+                  }
+                }
+                StructField(complexType.getName, StructType(fields))
+              // xs:sequence
+              case sequence: XmlSchemaSequence =>
+                // flatten xs:choice nodes
+                val fields = sequence.getItems.asScala.flatMap { member: XmlSchemaSequenceMember =>
+                    member match {
+                      case choice: XmlSchemaChoice => choice.getItems.asScala.map((_, true))
+                      case element: XmlSchemaElement => Seq((element, element.getMinOccurs == 0))
+                    }
+                  }.map { case (element: XmlSchemaElement, nullable) =>
+                    val baseStructField = getStructField(xmlSchema, element.getSchemaType)
+                    val field = StructField(element.getName, baseStructField.dataType, nullable)
+                    if (element.getMaxOccurs == 1) {
+                      field
+                    } else {
+                      StructField(element.getName, ArrayType(field.dataType))
+                    }
+                  }
+                StructField(complexType.getName, StructType(fields))
+            }
+        }
+    }
+  }
+
+  private def getStructType(xmlSchema: XmlSchema): StructType = {
+    val (qName, schemaElement) = xmlSchema.getElements.asScala.head
+    val schemaType = schemaElement.getSchemaType
+    if (schemaType.isAnonymous) {
+      schemaType.setName(qName.getLocalPart)
+    }
+    StructType(Seq(getStructField(xmlSchema, schemaType)))
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -298,7 +298,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("DSL test for failing fast") {
     val exceptionInParse = intercept[SparkException] {
       new XmlReader()
-        .withFailFast(true)
+        .withParseMode("FAILFAST")
         .xmlFile(spark, carsMalformedFile)
         .collect()
     }

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml.util
+
+import java.nio.file.Paths
+
+import org.apache.spark.sql.types.{ArrayType, StructField, StructType, StringType}
+import org.scalatest.funsuite.AnyFunSuite
+
+class XSDToSchemaSuite extends AnyFunSuite {
+
+  test("Basic parsing") {
+    val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/basket.xsd"))
+    val expectedSchema = StructType(Array(
+      StructField("basket", StructType(Array(
+        StructField("entry", ArrayType(
+          StructType(Array(
+            StructField("key", StringType),
+            StructField("value", StringType)
+          )))
+        ))
+      )))
+    )
+    assert(expectedSchema === parsedSchema)
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2020 Databricks
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Relates to #449 and @seddonm1 's gist.

Adds a basic XSDToSchema utility that can parse a Spark schema from _some_ XSDs, those defining a table-like schema with simple, complex and sequence types.