### PR TITLE
Rewrite of Schema inference, and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ When reading files the API accepts several options:
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
 * `ignoreSurroundingSpaces`: Defines whether or not surrounding whitespaces from values being read should be skipped. Default is false.
+* `treatZeroPrefixedStringsAsNumbers`: When inferring the schema, whether to treat zero prefixed numbers as Strings or Numbers
 * `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to 
 validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. 
 Note that if the same local path is not already also visible on the executors in the cluster, then the XSD and any others 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-xml"
 
-version := "0.10.0"
+version := "0.10.0.3-SNAPSHOT"
 
 organization := "com.databricks"
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -54,7 +54,7 @@ This file is divided into 3 sections:
 
   <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
     <parameters>
-      <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+      <parameter name="maxLineLength"><![CDATA[160]]></parameter>
       <parameter name="tabSize"><![CDATA[2]]></parameter>
       <parameter name="ignoreImports">true</parameter>
     </parameters>

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -52,6 +52,8 @@ private[xml] class XmlOptions(
     parameters.get("ignoreSurroundingSpaces").map(_.toBoolean).getOrElse(false)
   val parseMode = ParseMode.fromString(parameters.getOrElse("mode", PermissiveMode.name))
   val inferSchema = parameters.get("inferSchema").map(_.toBoolean).getOrElse(true)
+  val zeroPrefixedStringsAsNumber =
+    parameters.get("treatZeroPrefixedStringsAsNumbers").map(_.toBoolean).getOrElse(true)
   val rowValidationXSDPath = parameters.get("rowValidationXSDPath").orNull
 }
 

--- a/src/main/scala/com/databricks/spark/xml/XmlPath.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlPath.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Onedot AG.
+ *
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+package com.databricks.spark.xml
+
+case class XmlPath(elements: Seq[String]) {
+  val leafName = elements.lastOption.getOrElse("")
+
+  def isRoot: Boolean = elements == Nil
+
+  def isChildOf(parent: XmlPath): Boolean = {
+    val matching = elements.zip(parent.elements).view
+    parent != this && matching.length == parent.elements.length && matching.forall { case (left, right) => left == right }
+  }
+
+  def renameLeaf(newName: String): XmlPath = if (isRoot) {
+    throw new IllegalStateException(s"Cannot rename root element")
+  } else {
+    XmlPath(elements.dropRight(1) :+ newName)
+  }
+
+  def child(childName: String): XmlPath = XmlPath(elements :+ childName)
+
+  def parent: XmlPath = if (isRoot) {
+    throw new IllegalStateException(s"Root element does not have parents")
+  } else {
+    XmlPath(elements.dropRight(1))
+  }
+
+  override def toString: String = elements.mkString("/")
+}
+
+object XmlPath {
+  val root = XmlPath(Seq.empty)
+}

--- a/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlRelation.scala
@@ -18,12 +18,11 @@ package com.databricks.spark.xml
 import java.io.IOException
 
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.sources.{PrunedScan, InsertableRelation, BaseRelation, TableScan}
+import org.apache.spark.sql.sources.{ BaseRelation, InsertableRelation, PrunedScan }
 import org.apache.spark.sql.types._
-import com.databricks.spark.xml.util.{InferSchema, XmlFile}
+import com.databricks.spark.xml.util.{ InferSchema, XmlFile }
 import com.databricks.spark.xml.parsers.StaxXmlParser
 
 case class XmlRelation protected[spark] (

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -16,13 +16,11 @@
 package com.databricks.spark
 
 import org.apache.hadoop.io.compress.CompressionCodec
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{ArrayType, StructType}
-
+import org.apache.spark.sql.types.{ ArrayType, StructType }
 import com.databricks.spark.xml.parsers.StaxXmlParser
-import com.databricks.spark.xml.util.{InferSchema, XmlFile}
+import com.databricks.spark.xml.util.{ InferSchema, XmlFile }
 
 package object xml {
   /**

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -17,24 +17,22 @@ package com.databricks.spark.xml.parsers
 
 import java.io.StringReader
 
+import com.databricks.spark.xml.util.TypeCast._
+import com.databricks.spark.xml.util._
+import com.databricks.spark.xml.{ XmlOptions, XmlPath }
 import javax.xml.stream.XMLEventReader
-import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
+import javax.xml.stream.events.{ Attribute, Characters, EndDocument, EndElement, StartElement, XMLEvent }
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.Schema
-
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
-import scala.util.Try
-
-import org.slf4j.LoggerFactory
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import com.databricks.spark.xml.util.TypeCast._
-import com.databricks.spark.xml.XmlOptions
-import com.databricks.spark.xml.util._
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+import scala.util.control.NonFatal
 
 /**
  * Wraps parser to iteration process.
@@ -42,10 +40,9 @@ import com.databricks.spark.xml.util._
 private[xml] object StaxXmlParser extends Serializable {
   private val logger = LoggerFactory.getLogger(StaxXmlParser.getClass)
 
-  def parse(
-      xml: RDD[String],
-      schema: StructType,
-      options: XmlOptions): RDD[Row] = {
+  def parse(xml: RDD[String],
+            schema: StructType,
+            options: XmlOptions): RDD[Row] = {
     xml.mapPartitions { iter =>
       val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
       iter.flatMap { xml =>
@@ -61,43 +58,43 @@ private[xml] object StaxXmlParser extends Serializable {
     // is not manually specified, then fall back to DROPMALFORMED, which will return
     // null column values where parsing fails.
     val parseMode =
-      if (options.parseMode == PermissiveMode &&
-          !schema.fields.exists(_.name == options.columnNameOfCorruptRecord)) {
-        DropMalformedMode
-      } else {
-        options.parseMode
-      }
+    if (options.parseMode == PermissiveMode &&
+      !schema.fields.exists(_.name == options.columnNameOfCorruptRecord)) {
+      DropMalformedMode
+    } else {
+      options.parseMode
+    }
     val xsdSchema = Option(options.rowValidationXSDPath).map(ValidatorUtil.getSchema)
     doParseColumn(xml, schema, options, parseMode, xsdSchema).orNull
   }
 
   private def doParseColumn(xml: String,
-      schema: StructType,
-      options: XmlOptions,
-      parseMode: ParseMode,
-      xsdSchema: Option[Schema]): Option[Row] = {
+                            schema: StructType,
+                            options: XmlOptions,
+                            parseMode: ParseMode,
+                            xsdSchema: Option[Schema]): Option[Row] = {
     try {
       xsdSchema.foreach { schema =>
         schema.newValidator().validate(new StreamSource(new StringReader(xml)))
       }
-      val parser = StaxXmlParserUtils.filteredReader(xml)
+      val parser = new TrackingXmlEventReader(StaxXmlParserUtils.filteredReader(xml))
+
       val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
-      Some(convertObject(parser, schema, options, rootAttributes))
+      Some(convertObject(XmlPath(Seq(options.rowTag)), parser, schema, options, rootAttributes))
     } catch {
       case e: PartialResultException =>
-        failedRecord(xml, options, parseMode, schema,
-          e.cause, Some(e.partialResult))
+        failedRecord(xml, options, parseMode, schema, e.cause, Some(e.partialResult))
       case NonFatal(e) =>
         failedRecord(xml, options, parseMode, schema, e)
     }
   }
 
   private def failedRecord(record: String,
-      options: XmlOptions,
-      parseMode: ParseMode,
-      schema: StructType,
-      cause: Throwable = null,
-      partialResult: Option[Row] = None): Option[Row] = {
+                           options: XmlOptions,
+                           parseMode: ParseMode,
+                           schema: StructType,
+                           cause: Throwable = null,
+                           partialResult: Option[Row] = None): Option[Row] = {
     // create a row even if no corrupt record column is present
     parseMode match {
       case FailFastMode =>
@@ -133,21 +130,23 @@ private[xml] object StaxXmlParser extends Serializable {
    * Parse the current token (and related children) according to a desired schema
    */
   private[xml] def convertField(
-      parser: XMLEventReader,
-      dataType: DataType,
-      options: XmlOptions): Any = {
+                                 elementPath: XmlPath,
+                                 parser: TrackingXmlEventReader,
+                                 dataType: DataType,
+                                 options: XmlOptions): Any = {
     def convertComplicatedType(dt: DataType): Any = dt match {
-      case st: StructType => convertObject(parser, st, options)
-      case MapType(StringType, vt, _) => convertMap(parser, vt, options)
-      case ArrayType(st, _) => convertField(parser, st, options)
+      case st: StructType => convertObject(elementPath, parser, st, options)
+      case MapType(StringType, vt, _) => convertMap(elementPath, parser, vt, options)
+      case ArrayType(st, _) => convertField(elementPath, parser, st, options)
       case _: StringType => StaxXmlParserUtils.currentStructureAsString(parser)
     }
 
-    (parser.peek, dataType) match {
+    val peek = parser.peek
+    (peek, dataType) match {
       case (_: StartElement, dt: DataType) => convertComplicatedType(dt)
       case (_: EndElement, _: StringType) =>
         // Empty. It's null if these are explicitly treated as null, or "" is the null value
-        if (options.treatEmptyValuesAsNulls || options.nullValue == ""){
+        if (options.treatEmptyValuesAsNulls || options.nullValue == "") {
           null
         } else {
           ""
@@ -163,31 +162,34 @@ private[xml] object StaxXmlParser extends Serializable {
         val attributesOnly = st.fields.forall { f =>
           f.name == options.valueTag || f.name.startsWith(options.attributePrefix)
         }
-        if (attributesOnly) {
+        val convertedField = if (attributesOnly) {
           // If everything else is an attribute column, there's no complex structure.
           // Just return the value of the character element
           val dt = st.find(_.name == options.valueTag).get.dataType
+          parser.nextEvent()
           convertTo(c.getData, dt, options)
         } else {
           // Otherwise, ignore this character element, and continue parsing the following complex
           // structure
-          parser.next
-          convertObject(parser, st, options)
+          convertObject(elementPath, parser, st, options)
         }
+        convertedField
       case (c: Characters, _: DataType) if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide
         // if this is really data or space between other elements.
         val data = c.getData
-        parser.next
+        parser.nextEvent()
         parser.peek match {
           case _: StartElement => convertComplicatedType(dataType)
           case _: EndElement if data.isEmpty => null
           case _: EndElement if options.treatEmptyValuesAsNulls => null
           case _: EndElement => convertTo(data, dataType, options)
-          case _ => convertField(parser, dataType, options)
+          case _ => convertField(elementPath, parser, dataType, options)
         }
       case (c: Characters, dt: DataType) =>
-        convertTo(c.getData, dt, options)
+        val data = c.getData
+        parser.nextEvent()
+        convertTo(data, dt, options)
       case (e: XMLEvent, dt: DataType) =>
         throw new IllegalArgumentException(
           s"Failed to parse a value for data type $dt with event ${e.toString}")
@@ -198,9 +200,10 @@ private[xml] object StaxXmlParser extends Serializable {
    * Parse an object as map.
    */
   private def convertMap(
-      parser: XMLEventReader,
-      valueType: DataType,
-      options: XmlOptions): Map[String, Any] = {
+                          elementPath: XmlPath,
+                          parser: TrackingXmlEventReader,
+                          valueType: DataType,
+                          options: XmlOptions): Map[String, Any] = {
     val keys = ArrayBuffer.empty[String]
     val values = ArrayBuffer.empty[Any]
     var shouldStop = false
@@ -208,7 +211,7 @@ private[xml] object StaxXmlParser extends Serializable {
       parser.nextEvent match {
         case e: StartElement =>
           keys += e.getName.getLocalPart
-          values += convertField(parser, valueType, options)
+          values += convertField(elementPath, parser, valueType, options)
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
         case _ => // do nothing
@@ -221,9 +224,9 @@ private[xml] object StaxXmlParser extends Serializable {
    * Convert XML attributes to a map with the given schema types.
    */
   private def convertAttributes(
-      attributes: Array[Attribute],
-      schema: StructType,
-      options: XmlOptions): Map[String, Any] = {
+                                 attributes: Array[Attribute],
+                                 schema: StructType,
+                                 options: XmlOptions): Map[String, Any] = {
     val convertedValuesMap = collection.mutable.Map.empty[String, Any]
     val valuesMap = StaxXmlParserUtils.convertAttributesToValuesMap(attributes, options)
     valuesMap.foreach { case (f, v) =>
@@ -241,10 +244,11 @@ private[xml] object StaxXmlParser extends Serializable {
    * and end of a nested row and this function converts the events to a row.
    */
   private def convertObjectWithAttributes(
-      parser: XMLEventReader,
-      schema: StructType,
-      options: XmlOptions,
-      attributes: Array[Attribute] = Array.empty): Row = {
+                                           elementPath: XmlPath,
+                                           parser: TrackingXmlEventReader,
+                                           schema: StructType,
+                                           options: XmlOptions,
+                                           attributes: Array[Attribute] = Array.empty): Row = {
     // TODO: This method might have to be removed. Some logics duplicate `convertObject()`
     val row = new Array[Any](schema.length)
 
@@ -252,7 +256,7 @@ private[xml] object StaxXmlParser extends Serializable {
     val attributesMap = convertAttributes(attributes, schema, options)
 
     // Then, we read elements here.
-    val fieldsMap = convertField(parser, schema, options) match {
+    val fieldsMap = convertField(elementPath, parser, schema, options) match {
       case row: Row =>
         Map(schema.map(_.name).zip(row.toSeq): _*)
       case v if schema.fieldNames.contains(options.valueTag) =>
@@ -268,7 +272,9 @@ private[xml] object StaxXmlParser extends Serializable {
     val valuesMap = fieldsMap ++ attributesMap
     valuesMap.foreach { case (f, v) =>
       val nameToIndex = schema.map(_.name).zipWithIndex.toMap
-      nameToIndex.get(f).foreach { row(_) = v }
+      nameToIndex.get(f).foreach {
+        row(_) = v
+      }
     }
 
     if (valuesMap.isEmpty) {
@@ -284,15 +290,18 @@ private[xml] object StaxXmlParser extends Serializable {
    * Fields in the xml that are not defined in the requested schema will be dropped.
    */
   private def convertObject(
-      parser: XMLEventReader,
-      schema: StructType,
-      options: XmlOptions,
-      rootAttributes: Array[Attribute] = Array.empty): Row = {
+                             elementPath: XmlPath,
+                             parser: TrackingXmlEventReader,
+                             schema: StructType,
+                             options: XmlOptions,
+                             rootAttributes: Array[Attribute] = Array.empty): Row = {
     val row = new Array[Any](schema.length)
-    val nameToIndex = schema.map(_.name).zipWithIndex.toMap
+    val nameToIndex = schema.map(_.name).map(name => elementPath.child(name)).zipWithIndex.toMap
     // If there are attributes, then we process them first.
-    convertAttributes(rootAttributes, schema, options).toSeq.foreach { case (f, v) =>
-      nameToIndex.get(f).foreach { row(_) = v }
+    convertAttributes(rootAttributes, schema, options).toSeq.foreach { case (attributeName, attributeValue) =>
+      nameToIndex.get(elementPath.child(attributeName)).foreach {
+        row(_) = attributeValue
+      }
     }
     var badRecordException: Option[Throwable] = None
 
@@ -302,11 +311,10 @@ private[xml] object StaxXmlParser extends Serializable {
         case e: StartElement => try {
           val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
           val field = e.asStartElement.getName.getLocalPart
-
-          nameToIndex.get(field) match {
+          nameToIndex.get(elementPath.child(field)) match {
             case Some(index) => schema(index).dataType match {
               case st: StructType =>
-                row(index) = convertObjectWithAttributes(parser, st, options, attributes)
+                row(index) = convertObjectWithAttributes(elementPath.child(field), parser, st, options, attributes)
 
               case ArrayType(dt: DataType, _) =>
                 val values = Option(row(index))
@@ -314,26 +322,42 @@ private[xml] object StaxXmlParser extends Serializable {
                   .getOrElse(ArrayBuffer.empty[Any])
                 val newValue = dt match {
                   case st: StructType =>
-                    convertObjectWithAttributes(parser, st, options, attributes)
+                    convertObjectWithAttributes(elementPath.child(field), parser, st, options, attributes)
                   case dt: DataType =>
-                    convertField(parser, dt, options)
+                    convertField(elementPath.child(field), parser, dt, options)
                 }
                 row(index) = values :+ newValue
 
               case dt: DataType =>
-                row(index) = convertField(parser, dt, options)
+                row(index) = convertField(elementPath.child(field), parser, dt, options)
             }
 
             case None =>
-              StaxXmlParserUtils.skipChildren(parser)
+              parser.nextEvent()
+              StaxXmlParserUtils.skipChildren(field, parser)
           }
         } catch {
           case NonFatal(exception) if options.parseMode == PermissiveMode =>
             badRecordException = badRecordException.orElse(Some(exception))
         }
 
+        case c: Characters if !c.isWhiteSpace =>
+          nameToIndex.get(elementPath.child(options.valueTag)).map(index => index -> schema(index).dataType).foreach {
+            case (index, ArrayType(_: StringType, _)) =>
+              val existingValues = Option(row(index))
+                .map(_.asInstanceOf[ArrayBuffer[String]])
+                .getOrElse(ArrayBuffer.empty[String])
+              row(index) = existingValues :+ c.getData
+
+            case (index, StringType) =>
+              row(index) = Option(row(index)).getOrElse("") + c.getData
+          }
+
         case _: EndElement =>
-          shouldStop = StaxXmlParserUtils.checkEndElement(parser)
+          shouldStop = elementPath.isChildOf(parser.currentPath)
+
+        case _: EndDocument =>
+          shouldStop = true
 
         case _ => // do nothing
       }
@@ -345,4 +369,35 @@ private[xml] object StaxXmlParser extends Serializable {
       throw PartialResultException(Row.fromSeq(row), badRecordException.get)
     }
   }
+
+  class TrackingXmlEventReader(delegateReader: XMLEventReader) extends XMLEventReader with Iterator[XMLEvent] {
+    var currentPath: XmlPath = XmlPath.root
+
+    override def nextEvent(): XMLEvent = {
+      val nextEvent = delegateReader.nextEvent()
+      nextEvent match {
+        case startElement: StartElement => currentPath = currentPath.child(startElement.getName.getLocalPart)
+        case endElement: EndElement if currentPath.leafName == endElement.getName.getLocalPart => currentPath = currentPath.parent
+        case endElement: EndElement => throw new IllegalStateException(s"Found EndElement $endElement but we should be in $currentPath")
+        case _ => // ignore
+      }
+
+      nextEvent
+    }
+
+    override def hasNext: Boolean = delegateReader.hasNext
+
+    override def peek(): XMLEvent = delegateReader.peek
+
+    override def getElementText: String = delegateReader.getElementText
+
+    override def nextTag(): XMLEvent = delegateReader.nextTag
+
+    override def getProperty(s: String): AnyRef = delegateReader.getProperty(s)
+
+    override def close(): Unit = delegateReader.close()
+
+    override def next() = throw new NotImplementedError(s"next() on ${this.getClass.getSimpleName} is not implemented")
+  }
+
 }

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -18,21 +18,19 @@ package com.databricks.spark.xml.util
 import java.io.StringReader
 import java.util.Comparator
 
-import javax.xml.stream.XMLEventReader
-import javax.xml.stream.events.{Attribute, Characters, EndElement, StartElement, XMLEvent}
-import javax.xml.transform.stream.StreamSource
-
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.collection.Seq
-import scala.collection.mutable.ArrayBuffer
-import scala.util.control.NonFatal
-
-import com.databricks.spark.xml.XmlOptions
 import com.databricks.spark.xml.parsers.StaxXmlParserUtils
+import com.databricks.spark.xml.parsers.StaxXmlParserUtils.convertAttributesToValuesMap
 import com.databricks.spark.xml.util.TypeCast._
+import com.databricks.spark.xml.{ XmlPath, XmlOptions }
+import javax.xml.stream.events.{ Attribute, Characters, EndDocument, EndElement, StartElement, XMLEvent }
+import javax.xml.stream.{ XMLEventReader, XMLStreamConstants }
+import javax.xml.transform.stream.StreamSource
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
+
+import scala.collection.JavaConverters._
+import scala.collection.Seq
+import scala.util.control.NonFatal
 
 private[xml] object InferSchema {
 
@@ -40,7 +38,7 @@ private[xml] object InferSchema {
    * Copied from internal Spark api
    * [[org.apache.spark.sql.catalyst.analysis.TypeCoercion]]
    */
-  private val numericPrecedence: IndexedSeq[DataType] =
+  private[this] val numericPrecedence: IndexedSeq[DataType] =
     IndexedSeq[DataType](
       ByteType,
       ShortType,
@@ -51,7 +49,7 @@ private[xml] object InferSchema {
       TimestampType,
       DecimalType.SYSTEM_DEFAULT)
 
-  private val findTightestCommonTypeOfTwo: (DataType, DataType) => Option[DataType] = {
+  private[this] val findTightestCommonTypeOfTwo: (DataType, DataType) => Option[DataType] = {
     case (t1, t2) if t1 == t2 => Some(t1)
 
     // Promote numeric types to the highest of the two
@@ -75,6 +73,7 @@ private[xml] object InferSchema {
    *   3. Replace any remaining null fields with string, the top type
    */
   def infer(xml: RDD[String], options: XmlOptions): StructType = {
+    implicit val xmlOptions = options
     val schemaData = if (options.samplingRatio > 0.99) {
       xml
     } else {
@@ -91,16 +90,15 @@ private[xml] object InferSchema {
           }
 
           val parser = StaxXmlParserUtils.filteredReader(xml)
-          val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
-          Some(inferObject(parser, options, rootAttributes))
+          Some(inferObject(parser))
         } catch {
-          case NonFatal(_) if options.parseMode == PermissiveMode =>
-            Some(StructType(Seq(StructField(options.columnNameOfCorruptRecord, StringType))))
+          case NonFatal(e) if options.parseMode == PermissiveMode =>
+            Some(StructType(Seq(StructField(xmlOptions.columnNameOfCorruptRecord, StringType))))
           case NonFatal(_) =>
             None
         }
       }
-    }.fold(StructType(Seq()))(compatibleType(options))
+    }.fold(StructType(Seq()))(compatibleType)
 
     canonicalizeType(rootType) match {
       case Some(st: StructType) => st
@@ -110,7 +108,7 @@ private[xml] object InferSchema {
     }
   }
 
-  private def inferFrom(datum: String, options: XmlOptions): DataType = {
+  private[this] def inferFrom(datum: String)(implicit options: XmlOptions): DataType = {
     val value = if (datum != null && options.ignoreSurroundingSpaces) {
       datum.trim()
     } else {
@@ -121,6 +119,9 @@ private[xml] object InferSchema {
       value match {
         case null => NullType
         case v if v.isEmpty => NullType
+        case v if !options.zeroPrefixedStringsAsNumber
+          && v.length > 1
+          && v.headOption.contains('0') => StringType
         case v if isLong(v) => LongType
         case v if isInteger(v) => IntegerType
         case v if isDouble(v) => DoubleType
@@ -133,124 +134,79 @@ private[xml] object InferSchema {
     }
   }
 
-  @tailrec
-  private def inferField(parser: XMLEventReader, options: XmlOptions): DataType = {
-    parser.peek match {
-      case _: EndElement => NullType
-      case _: StartElement => inferObject(parser, options)
-      case c: Characters if c.isWhiteSpace =>
-        // When `Characters` is found, we need to look further to decide
-        // if this is really data or space between other elements.
-        val data = c.getData
-        parser.nextEvent()
-        parser.peek match {
-          case _: StartElement => inferObject(parser, options)
-          case _: EndElement if data.isEmpty => NullType
-          case _: EndElement if options.treatEmptyValuesAsNulls => NullType
-          case _: EndElement => StringType
-          case _ => inferField(parser, options)
-        }
-      case c: Characters if !c.isWhiteSpace =>
-        // This could be the characters of a character-only element, or could have mixed
-        // characters and other complex structure
-        val characterType = inferFrom(c.getData, options)
-        parser.nextEvent()
-        parser.peek match {
-          case _: StartElement =>
-            // Some more elements follow; so ignore the characters.
-            // Use the schema of the rest
-            inferObject(parser, options).asInstanceOf[StructType]
-          case _ =>
-            // That's all, just the character-only body; use that as the type
-            characterType
-        }
-      case e: XMLEvent =>
-        throw new IllegalArgumentException(s"Failed to parse data with unexpected event $e")
+  private[this] def inferObject(parser: XMLEventReader)(implicit xmlOptions: XmlOptions): DataType = {
+
+    def getAttributeDataTypes(startElement: StartElement): Seq[StructField] = {
+      val attributes = startElement.getAttributes.asScala.collect { case a: Attribute => a }.toArray
+
+      convertAttributesToValuesMap(attributes, xmlOptions)
+        .mapValues(inferFrom)
+        .map { case (name, dataType) => StructField(name, dataType) }
+        .toSeq
     }
-  }
 
-  /**
-   * Infer the type of a xml document from the parser's token stream
-   */
-  private def inferObject(
-      parser: XMLEventReader,
-      options: XmlOptions,
-      rootAttributes: Array[Attribute] = Array.empty): DataType = {
-    val builder = Array.newBuilder[StructField]
-    val nameToDataType = collection.mutable.Map.empty[String, ArrayBuffer[DataType]]
-    // If there are attributes, then we should process them first.
-    val rootValuesMap =
-      StaxXmlParserUtils.convertAttributesToValuesMap(rootAttributes, options)
-    rootValuesMap.foreach {
-      case (f, v) =>
-        nameToDataType += (f -> ArrayBuffer(inferFrom(v, options)))
-    }
-    var shouldStop = false
-    while (!shouldStop) {
-      parser.nextEvent match {
-        case e: StartElement =>
-          val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
-          val valuesMap = StaxXmlParserUtils.convertAttributesToValuesMap(attributes, options)
-          val inferredType = inferField(parser, options) match {
-            case st: StructType if valuesMap.nonEmpty =>
-              // Merge attributes to the field
-              val nestedBuilder = Array.newBuilder[StructField]
-              nestedBuilder ++= st.fields
-              valuesMap.foreach {
-                case (f, v) =>
-                  nestedBuilder += StructField(f, inferFrom(v, options), nullable = true)
-              }
-              val nesterBuilderArr = nestedBuilder.result()
-              java.util.Arrays.sort(nesterBuilderArr, structFieldComparator)
-              StructType(nesterBuilderArr)
-
-            case dt: DataType if valuesMap.nonEmpty =>
-              // We need to manually add the field for value.
-              val nestedBuilder = Array.newBuilder[StructField]
-              nestedBuilder += StructField(options.valueTag, dt, nullable = true)
-              valuesMap.foreach {
-                case (f, v) =>
-                  nestedBuilder += StructField(f, inferFrom(v, options), nullable = true)
-              }
-              val nesterBuilderArr = nestedBuilder.result()
-              java.util.Arrays.sort(nesterBuilderArr, structFieldComparator)
-              StructType(nesterBuilderArr)
-
-            case dt: DataType => dt
-          }
-          // Add the field and datatypes so that we can check if this is ArrayType.
-          val field = e.asStartElement.getName.getLocalPart
-          val dataTypes = nameToDataType.getOrElse(field, ArrayBuffer.empty[DataType])
-          dataTypes += inferredType
-          nameToDataType += (field -> dataTypes)
-
-        case _: EndElement =>
-          shouldStop = StaxXmlParserUtils.checkEndElement(parser)
-
-        case _ => // do nothing
+    def collapseSingleValueStructs(dataType: DataType): DataType = {
+      val valueTag = xmlOptions.valueTag
+      dataType match {
+        case StructType(fields) if fields.isEmpty && xmlOptions.nullValue != null => inferFrom(xmlOptions.nullValue)
+        case StructType(Array(StructField(`valueTag`, dataType, _, _))) => dataType
+        case StructType(fields) => StructType(fields.map(field => field.copy(dataType = collapseSingleValueStructs(field.dataType))))
+        case ArrayType(elementType, _) => ArrayType(collapseSingleValueStructs(elementType))
+        case nonStructDataType: DataType => nonStructDataType
       }
     }
-    // We need to manually merges the fields having the sames so that
-    // This can be inferred as ArrayType.
-    nameToDataType.foreach {
-      case (field, dataTypes) if dataTypes.length > 1 =>
-        val elementType = dataTypes.reduceLeft(InferSchema.compatibleType(options))
-        builder += StructField(field, ArrayType(elementType), nullable = true)
-      case (field, dataTypes) =>
-        builder += StructField(field, dataTypes.head, nullable = true)
+
+    @scala.annotation.tailrec
+    def processEvent(currentPath: XmlPath, nextEvent: XMLEvent, inProgressSchema: XmlElementTypes): DataType = {
+      nextEvent match {
+        case startElement: StartElement =>
+          val fields = getAttributeDataTypes(startElement)
+          val currentElementPath = currentPath.child(startElement.getName.getLocalPart)
+          processEvent(currentElementPath, parser.nextEvent(), inProgressSchema.addValue(currentElementPath, StructType(fields)))
+
+        case characters: Characters if !characters.isWhiteSpace =>
+          processEvent(currentPath, parser.nextEvent(),
+            inProgressSchema.appendToType(currentPath, xmlOptions.valueTag, inferFrom(characters.getData)))
+
+        case end: EndElement if end.getName.getLocalPart != currentPath.leafName =>
+          throw new IllegalStateException(s"Expected closing element for $currentPath but found ${end.getName.getLocalPart}")
+
+        case _: EndElement =>
+          val mergedSchema = inProgressSchema.children(currentPath).foldLeft(inProgressSchema) {
+            case (runningSchema, (name, dataType +: Nil)) => runningSchema.appendToType(currentPath, name, dataType)
+            case (runningSchema, (name, dataTypes)) => runningSchema.appendToType(currentPath, name, ArrayType(dataTypes.reduceLeft(compatibleType(_, _))))
+          }.dropChildren(currentPath)
+
+          val withEmptyAsNull = mergedSchema.currentType(currentPath) match {
+            case StructType(fields) if xmlOptions.treatEmptyValuesAsNulls && fields.isEmpty => mergedSchema.updateCurrentType(currentPath, NullType)
+            case _ => mergedSchema
+          }
+
+          if (currentPath.parent.isRoot) {
+            withEmptyAsNull.currentType(currentPath)
+          } else {
+            processEvent(currentPath.parent, parser.nextEvent(), withEmptyAsNull)
+          }
+        case _: EndDocument =>
+          inProgressSchema.aggregatedType
+        case _ =>
+          processEvent(currentPath, parser.nextEvent(), inProgressSchema)
+      }
     }
 
-    val fields = builder.result()
-    // Note: other code relies on this sorting for correctness, so don't remove it!
-    java.util.Arrays.sort(fields, structFieldComparator)
-    StructType(fields)
+    val rootEvent = StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.START_ELEMENT).asStartElement()
+    val detectedSchema = processEvent(
+      currentPath = XmlPath.root,
+      nextEvent = rootEvent,
+      inProgressSchema = new XmlElementTypes()(xmlOptions))
+    collapseSingleValueStructs(detectedSchema)
   }
 
   /**
    * Convert NullType to StringType and remove StructTypes with no fields
    */
-  private def canonicalizeType(dt: DataType): Option[DataType] = dt match {
-    case at @ ArrayType(elementType, _) =>
+  private[this] def canonicalizeType(dt: DataType): Option[DataType] = dt match {
+    case at@ArrayType(elementType, _) =>
       for {
         canonicalType <- canonicalizeType(elementType)
       } yield {
@@ -279,9 +235,17 @@ private[xml] object InferSchema {
   /**
    * Returns the most general data type for two given data types.
    */
-  private[xml] def compatibleType(options: XmlOptions)(t1: DataType, t2: DataType): DataType = {
+  private[this] def compatibleType(t1: DataType, t2: DataType)(implicit options: XmlOptions): DataType = {
+    def matchStructAndValueTag(struct: StructType, dataType: DataType) = {
+      val valueIndex = struct.fieldNames.indexOf(options.valueTag)
+      val valueField = struct.fields(valueIndex)
+      val valueDataType = compatibleType(valueField.dataType, dataType)
+      struct.fields(valueIndex) = StructField(options.valueTag, valueDataType, nullable = true)
+      struct
+    }
+
     // TODO: Optimise this logic.
-    findTightestCommonTypeOfTwo(t1, t2).getOrElse {
+    val resultType = findTightestCommonTypeOfTwo(t1, t2).getOrElse {
       // t1 or t2 is a StructType, ArrayType, or an unexpected type.
       (t1, t2) match {
         // Double support larger range than fixed decimal, DecimalType.Maximum should be enough
@@ -303,7 +267,7 @@ private[xml] object InferSchema {
         case (StructType(fields1), StructType(fields2)) =>
           val newFields = (fields1 ++ fields2).groupBy(_.name).map {
             case (name, fieldTypes) =>
-              val dataType = fieldTypes.view.map(_.dataType).reduce(compatibleType(options))
+              val dataType = fieldTypes.view.map(_.dataType).reduce(compatibleType(_, _))
               StructField(name, dataType, nullable = true)
           }
           val newFieldsArr = newFields.toArray
@@ -312,32 +276,24 @@ private[xml] object InferSchema {
 
         case (ArrayType(elementType1, containsNull1), ArrayType(elementType2, containsNull2)) =>
           ArrayType(
-            compatibleType(options)(elementType1, elementType2), containsNull1 || containsNull2)
+            compatibleType(elementType1, elementType2), containsNull1 || containsNull2)
 
         // In XML datasource, since StructType can be compared with ArrayType.
         // In this case, ArrayType wraps the StructType.
         case (ArrayType(ty1, _), ty2) =>
-          ArrayType(compatibleType(options)(ty1, ty2))
+          ArrayType(compatibleType(ty1, ty2))
 
         case (ty1, ArrayType(ty2, _)) =>
-          ArrayType(compatibleType(options)(ty1, ty2))
+          ArrayType(compatibleType(ty1, ty2))
 
         // As this library can infer an element with attributes as StructType whereas
         // some can be inferred as other non-structural data types, this case should be
         // treated.
-        case (st: StructType, dt: DataType) if st.fieldNames.contains(options.valueTag) =>
-          val valueIndex = st.fieldNames.indexOf(options.valueTag)
-          val valueField = st.fields(valueIndex)
-          val valueDataType = compatibleType(options)(valueField.dataType, dt)
-          st.fields(valueIndex) = StructField(options.valueTag, valueDataType, nullable = true)
-          st
+        case (st: StructType, dt: DataType) if st.fieldNames.contains(options.valueTag) => matchStructAndValueTag(st, dt)
+        case (dt: DataType, st: StructType) if st.fieldNames.contains(options.valueTag) => matchStructAndValueTag(st, dt)
 
-        case (dt: DataType, st: StructType) if st.fieldNames.contains(options.valueTag) =>
-          val valueIndex = st.fieldNames.indexOf(options.valueTag)
-          val valueField = st.fields(valueIndex)
-          val valueDataType = compatibleType(options)(dt, valueField.dataType)
-          st.fields(valueIndex) = StructField(options.valueTag, valueDataType, nullable = true)
-          st
+        case (st: StructType, dt: DataType) => StructType(st.fields :+ StructField(options.valueTag, dt))
+        case (dt: DataType, st: StructType) => StructType(st.fields :+ StructField(options.valueTag, dt))
 
         // TODO: These null type checks should be in `findTightestCommonTypeOfTwo`.
         case (_, NullType) => t1
@@ -346,5 +302,74 @@ private[xml] object InferSchema {
         case (_, _) => StringType
       }
     }
+    resultType
   }
+
+  class XmlElementTypes(detectedDataTypes: Map[XmlPath, Seq[DataType]] = Map.empty[XmlPath, Seq[DataType]]
+                       )(implicit xmlOptions: XmlOptions) {
+
+    def addValue(key: XmlPath, value: DataType): XmlElementTypes = detectedDataTypes.get(key) match {
+      case Some(seq) => new XmlElementTypes(detectedDataTypes + (key -> (value +: seq)))
+      case None => new XmlElementTypes(detectedDataTypes + (key -> Seq(value)))
+    }
+
+    def appendToType(key: XmlPath, name: String, dataType: DataType): XmlElementTypes = detectedDataTypes.get(key) match {
+      case Some((current@StructType(fields)) +: remaining) if name == xmlOptions.valueTag =>
+        val mergedType = fields.find(_.name == xmlOptions.valueTag) match {
+          case None => current.add(name, dataType)
+          case Some(StructField(_, ArrayType(arrayDataType, _), _, _)) =>
+            StructType(current.filterNot(_.name == xmlOptions.valueTag))
+              .add(xmlOptions.valueTag, ArrayType(compatibleType(arrayDataType, dataType)))
+          case Some(field) =>
+            StructType(current.filterNot(_.name == xmlOptions.valueTag))
+              .add(xmlOptions.valueTag, ArrayType(compatibleType(field.dataType, dataType)))
+        }
+        new XmlElementTypes(detectedDataTypes + (key -> (mergedType +: remaining)))
+
+      case Some((current: StructType) +: remaining) =>
+        new XmlElementTypes(detectedDataTypes + (key -> (current.add(name, dataType) +: remaining)))
+      case Some((current: ArrayType) +: remaining) =>
+        new XmlElementTypes(detectedDataTypes + (key -> (StructType(Seq(StructField(xmlOptions.valueTag, current), StructField(name, dataType))) +: remaining)))
+      case Some(current +: remaining) if name == xmlOptions.valueTag =>
+        new XmlElementTypes(detectedDataTypes + (key -> (ArrayType(compatibleType(current, dataType)) +: remaining)))
+      case Some((_: NullType) +: remaining) =>
+        new XmlElementTypes(detectedDataTypes + (key -> (StructType(Seq(StructField(name, dataType))) +: remaining)))
+      case Some(current +: _) =>
+        throw new IllegalStateException(s"Didn't expect to see a value data type $current for $key")
+      case None => throw new IllegalStateException(s"No type recorded yet for $key")
+    }
+
+    def currentType(key: XmlPath): DataType = detectedDataTypes.get(key) match {
+      case Some(current +: _) => current
+      case None => throw new IllegalStateException(s"Expected to find $key in ${asString()}")
+    }
+
+    def updateCurrentType(key: XmlPath, updatedType: DataType): XmlElementTypes = detectedDataTypes.get(key) match {
+      case Some(_ +: remaining) => new XmlElementTypes(detectedDataTypes + (key -> (updatedType +: remaining)))
+      case None => throw new IllegalStateException(s"Expected to find $key in ${asString()}")
+    }
+
+    def children(path: XmlPath): Map[String, Seq[DataType]] = {
+      detectedDataTypes.filterKeys(_.isChildOf(path)).map {
+        case (key, dataTypes) => key.leafName -> dataTypes
+      }
+    }
+
+    def dropChildren(parent: XmlPath): XmlElementTypes = {
+      new XmlElementTypes(detectedDataTypes.filterNot { case (path, _) => path.isChildOf(parent) })
+    }
+
+    def aggregatedType: DataType = detectedDataTypes.toSeq match {
+      case (_, dataType +: Nil) +: Nil => dataType
+      case _ => throw new IllegalStateException(s"Types are not yet aggregated in ${asString()}")
+    }
+
+    def asString(): String = {
+      detectedDataTypes.map {
+        case (key, value +: Nil) => s"$key -> $value"
+        case (key, values) => s"$key -> ${values.mkString("[\n\t\t", "\n\t\t", "]")}"
+      }.mkString("\n\t", "\n\t", "")
+    }
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtilsSuite.scala
@@ -72,19 +72,20 @@ final class StaxXmlParserUtilsSuite extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("Skip XML children") {
-    val input = <ROW><info>
-      <name>Sam Mad Dog Smith</name><amount><small>1</small>
-        <large>9</large></amount></info><abc>2</abc><test>2</test></ROW>
+    val input = <ROW>
+      <info>
+        <name>Sam Mad Dog Smith</name> <amount>
+        <small>1</small>
+        <large>9</large>
+      </amount>
+      </info> <abc>2</abc> <test>2</test>
+    </ROW>
     val parser = factory.createXMLEventReader(new StringReader(input.toString))
     // We assume here it's reading the value within `id` field.
     StaxXmlParserUtils.skipUntil(parser, XMLStreamConstants.CHARACTERS)
-    StaxXmlParserUtils.skipChildren(parser)
-    assert(parser.nextEvent().asEndElement().getName.getLocalPart === "info")
-    parser.next()
-    StaxXmlParserUtils.skipChildren(parser)
-    assert(parser.nextEvent().asEndElement().getName.getLocalPart === "abc")
-    parser.next()
-    StaxXmlParserUtils.skipChildren(parser)
-    assert(parser.nextEvent().asEndElement().getName.getLocalPart === "test")
+    StaxXmlParserUtils.skipChildren("info", parser)
+    assert(parser.nextEvent().asStartElement().getName.getLocalPart === "abc")
+    StaxXmlParserUtils.skipChildren("abc", parser)
+    assert(parser.nextEvent().asStartElement().getName.getLocalPart === "test")
   }
 }


### PR DESCRIPTION
* Root element with text and sub elements no longer discard the text
* Ability to treat zero prefixed numbers as either Strings or Numbers
* Correctly handle nested elements with same name as an ascendant element