### PR TITLE
Adding ability to supress rootTag and include header

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ This package allows reading XML files in local or distributed filesystem as [Spa
 When reading files the API accepts several options:
 
 * `path`: Location of files. Similar to Spark can accept standard Hadoop globbing expressions.
-* `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`.
+* `rowTag`: The row tag of your xml files to treat as a row. For example, in this xml `<books> <book><book> ...</books>`, the appropriate value would be `book`. Default is `ROW`. An empty rootTag will omit a root tag entirely
+* `header`: A raw header to add at the top of the output file. Can be used to add document encoding declaration
 * `samplingRatio`: Sampling ratio for inferring schema (0.0 ~ 1). Default is 1. Possible types are `StructType`, `ArrayType`, `StringType`, `LongType`, `DoubleType`, `BooleanType`, `TimestampType` and `NullType`, unless user provides a schema for this.
 * `excludeAttribute` : Whether you want to exclude attributes in elements or not. Default is false.
 * `treatEmptyValuesAsNulls` : (DEPRECATED: use `nullValue` set to `""`) Whether you want to treat whitespaces as a null value. Default is false

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -33,6 +33,7 @@ private[xml] class XmlOptions(
   val rowTag = parameters.getOrElse("rowTag", XmlOptions.DEFAULT_ROW_TAG)
   require(rowTag.nonEmpty, "'rowTag' option should not be empty string.")
   val rootTag = parameters.getOrElse("rootTag", XmlOptions.DEFAULT_ROOT_TAG)
+  val header = parameters.getOrElse("header", XmlOptions.DEFAULT_NULL_VALUE)
   val samplingRatio = parameters.get("samplingRatio").map(_.toDouble).getOrElse(1.0)
   require(samplingRatio > 0, s"samplingRatio ($samplingRatio) should be greater than 0")
   val excludeAttributeFlag = parameters.get("excludeAttribute").map(_.toBoolean).getOrElse(false)

--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -93,7 +93,12 @@ private[xml] object XmlFile {
         override def next: String = {
           if (iter.nonEmpty) {
             if (firstRow) {
-              indentingXmlWriter.writeStartElement(options.rootTag)
+              if (!options.header.isEmpty) {
+                writer.append(options.header)
+              }
+              if (!options.rootTag.isEmpty) {
+                indentingXmlWriter.writeStartElement(options.rootTag)
+              }
               firstRow = false
             }
             val xml = {
@@ -109,7 +114,9 @@ private[xml] object XmlFile {
           } else {
             if (!firstRow) {
               lastRow = false
-              indentingXmlWriter.writeEndElement()
+              if (!options.rootTag.isEmpty) {
+                indentingXmlWriter.writeEndElement()
+              }
               indentingXmlWriter.close()
               writer.toString
             } else {


### PR DESCRIPTION
This PR adds the ability to suppress the rootTag (by setting the value to "") and to include a raw header (such as `<?xml version='1.0' encoding='UTF-8'>)