### PR TITLE
support include statement with relative path

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -39,8 +39,11 @@ object XSDToSchema {
    */
   @Experimental
   def read(xsdFile: File): StructType = {
-    val xmlSchema = new XmlSchemaCollection().read(
+    val xmlSchemaCollection = new XmlSchemaCollection()
+    xmlSchemaCollection.setBaseUri(xsdFile.getParent)
+    val xmlSchema = xmlSchemaCollection.read(
       new InputStreamReader(new FileInputStream(xsdFile), StandardCharsets.UTF_8))
+
     getStructType(xmlSchema)
   }
 

--- a/src/test/resources/include-example/first.xsd
+++ b/src/test/resources/include-example/first.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:include schemaLocation="second.xsd" />
+    <xs:element name="basket" type="basket"/>
+</xs:schema>

--- a/src/test/resources/include-example/second.xsd
+++ b/src/test/resources/include-example/second.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:complexType name="basket">
+        <xs:sequence>
+            <xs:element name="entry" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="key" minOccurs="0" type="xs:anyType"/>
+                        <xs:element name="value" minOccurs="0" type="xs:anyType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -38,4 +38,19 @@ class XSDToSchemaSuite extends AnyFunSuite {
     assert(expectedSchema === parsedSchema)
   }
 
+  test("Relative path parsing") {
+    val parsedSchema = XSDToSchema.read(
+      Paths.get("src/test/resources/include-example/first.xsd"))
+    val expectedSchema = StructType(Array(
+      StructField("basket", StructType(Array(
+        StructField("entry", ArrayType(
+          StructType(Array(
+            StructField("key", StringType),
+            StructField("value", StringType)
+          )))
+        ))
+      )))
+    )
+    assert(expectedSchema === parsedSchema)
+  }
 }


### PR DESCRIPTION
The current parser does not support specifying the base URI, as a consequence relative imports fail. 
In this PR:

- Set BaseURI when reading xsd schemas