### PR TITLE
Preserve attributes when reconstructing string field from XML

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParserUtils.scala
@@ -143,7 +143,11 @@ private[xml] object StaxXmlParserUtils {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          xmlString += "<" + e.getName + ">"
+          val attributes = e.getAttributes.asScala.map { a =>
+            val att = a.asInstanceOf[Attribute]
+            " " + att.getName + "=\"" + att.getValue + "\""
+          }.mkString("")
+          xmlString += "<" + e.getName + attributes + ">"
           xmlString += convertChildren()
         case e: EndElement =>
           xmlString += "</" + e.getName + ">"

--- a/src/test/resources/cars-attribute.xml
+++ b/src/test/resources/cars-attribute.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>
+        <year>2015</year>
+        <make>Chevy</make>
+        <model>Volt</model>
+        <comment foo="bar">No</comment>
+    </ROW>
+</ROWSET>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -53,6 +53,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   private val carsFileBzip2 = resDir + "cars.xml.bz2"
   private val carsNoIndentationFile = resDir + "cars-no-indentation.xml"
   private val carsMixedAttrNoChildFile = resDir + "cars-mixed-attr-no-child.xml"
+  private val carsAttributes = resDir + "cars-attribute.xml"
   private val booksAttributesInNoChild = resDir + "books-attributes-in-no-child.xml"
   private val carsUnbalancedFile = resDir + "cars-unbalanced-elements.xml"
   private val carsMalformedFile = resDir + "cars-malformed.xml"
@@ -1251,6 +1252,17 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
 
     assert(whitespaceDF.count() === 1)
     assert(whitespaceDF.take(1).head.getAs[String]("_corrupt_record") !== null)
+  }
+  
+  test("XML in String field preserves attributes") {
+    val schema = buildSchema(field("ROW"))
+    val result = spark.read
+      .option("rowTag", "ROWSET")
+      .schema(schema)
+      .xml(carsAttributes)
+      .collect()
+    assert(result.head.get(0) ===
+      "<year>2015</year><make>Chevy</make><model>Volt</model><comment foo=\"bar\">No</comment>")
   }
 
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1253,7 +1253,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(whitespaceDF.count() === 1)
     assert(whitespaceDF.take(1).head.getAs[String]("_corrupt_record") !== null)
   }
-  
+
   test("XML in String field preserves attributes") {
     val schema = buildSchema(field("ROW"))
     val result = spark.read


### PR DESCRIPTION
Resolves https://github.com/databricks/spark-xml/issues/375

When reconstructing the value of a string field, where the element's children are XML, the XML is parsed then reconstructed (TODO: maybe one day this can be avoided). Attributes aren't preserved. This puts them back.