### PR TITLE
Fix error in parsing XSD types; handle attributes on all elements; more correctly handle nullability in XSDs

### DIFF
--- a/src/test/resources/catalog.xsd
+++ b/src/test/resources/catalog.xsd
@@ -1,0 +1,41 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="catalog">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="product">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="catalog_item" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="item_number"/>
+                    <xs:element type="xs:float" name="price"/>
+                    <xs:element name="size" maxOccurs="unbounded" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="color_swatch" maxOccurs="unbounded" minOccurs="0">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute type="xs:string" name="image" use="optional"/>
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute type="xs:string" name="description" use="optional"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute type="xs:string" name="gender" use="optional"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="description"/>
+            <xs:attribute type="xs:string" name="product_image"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/xml/TestUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.xml
+
+import org.apache.spark.sql.types.{ArrayType, DataType, StringType, StructField, StructType}
+
+private[xml] object TestUtils {
+
+  def buildSchema(fields: StructField*): StructType = StructType(fields)
+
+  def field(name: String, dataType: DataType = StringType, nullable: Boolean = true): StructField =
+    StructField(name, dataType, nullable)
+
+  def struct(fields: StructField*): StructType = buildSchema(fields: _*)
+
+  def struct(name: String, fields: StructField*): StructField = field(name, struct(fields: _*))
+
+  def structArray(name: String, fields: StructField*): StructField =
+    field(name, ArrayType(struct(fields: _*)))
+
+  def array(name: String, dataType: DataType): StructField = field(name, ArrayType(dataType))
+
+}

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.io.compress.GzipCodec
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
+import com.databricks.spark.xml.TestUtils._
 import com.databricks.spark.xml.XmlOptions._
 import com.databricks.spark.xml.functions._
 import com.databricks.spark.xml.util._
@@ -130,29 +131,6 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   private def getEmptyTempDir(): Path = {
     Files.createTempDirectory(tempDir, "test")
   }
-
-  // Utilities to simplify schema specification:
-
-  private def buildSchema(fields: StructField*): StructType =
-    StructType(fields)
-
-  private def field(
-      name: String,
-      dataType: DataType = StringType,
-      nullable: Boolean = true): StructField =
-    StructField(name, dataType, nullable)
-
-  private def struct(fields: StructField*): StructType =
-    buildSchema(fields: _*)
-
-  private def struct(name: String, fields: StructField*): StructField =
-    field(name, struct(fields: _*))
-
-  private def structArray(name: String, fields: StructField*): StructField =
-    field(name, ArrayType(struct(fields: _*)))
-
-  private def array(name: String, dataType: DataType): StructField =
-    field(name, ArrayType(dataType))
 
   // Tests
 

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -18,39 +18,56 @@ package com.databricks.spark.xml.util
 
 import java.nio.file.Paths
 
-import org.apache.spark.sql.types.{ArrayType, StructField, StructType, StringType}
+import org.apache.spark.sql.types.FloatType
 import org.scalatest.funsuite.AnyFunSuite
+
+import com.databricks.spark.xml.TestUtils._
 
 class XSDToSchemaSuite extends AnyFunSuite {
 
   test("Basic parsing") {
     val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/basket.xsd"))
-    val expectedSchema = StructType(Array(
-      StructField("basket", StructType(Array(
-        StructField("entry", ArrayType(
-          StructType(Array(
-            StructField("key", StringType),
-            StructField("value", StringType)
-          )))
-        ))
-      )))
-    )
+    val expectedSchema = buildSchema(
+      struct("basket",
+        structArray("entry",
+          field("key"),
+          field("value"))))
     assert(expectedSchema === parsedSchema)
   }
 
   test("Relative path parsing") {
     val parsedSchema = XSDToSchema.read(
       Paths.get("src/test/resources/include-example/first.xsd"))
-    val expectedSchema = StructType(Array(
-      StructField("basket", StructType(Array(
-        StructField("entry", ArrayType(
-          StructType(Array(
-            StructField("key", StringType),
-            StructField("value", StringType)
-          )))
-        ))
-      )))
-    )
+    val expectedSchema = buildSchema(
+      struct("basket",
+        structArray("entry",
+          field("key"),
+          field("value"))))
     assert(expectedSchema === parsedSchema)
   }
+  
+  test("Test schema types and attributes") {
+    val parsedSchema = XSDToSchema.read(
+      Paths.get("src/test/resources/catalog.xsd"))
+    val expectedSchema = buildSchema(
+      field("catalog",
+        struct(
+          field("product",
+            struct(
+              structArray("catalog_item",
+                field("item_number", nullable = false),
+                field("price", FloatType, nullable = false),
+                structArray("size",
+                  structArray("color_swatch",
+                    field("_VALUE"),
+                    field("_image")),
+                  field("_description")),
+                field("_gender")),
+              field("_description"),
+              field("_product_image")),
+            nullable = false)),
+        nullable = false))
+    assert(expectedSchema === parsedSchema)
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -28,10 +28,11 @@ class XSDToSchemaSuite extends AnyFunSuite {
   test("Basic parsing") {
     val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/basket.xsd"))
     val expectedSchema = buildSchema(
-      struct("basket",
-        structArray("entry",
-          field("key"),
-          field("value"))))
+      field("basket",
+        struct(
+          structArray("entry",
+            field("key"),
+            field("value"))), nullable = false))
     assert(expectedSchema === parsedSchema)
   }
 
@@ -39,10 +40,11 @@ class XSDToSchemaSuite extends AnyFunSuite {
     val parsedSchema = XSDToSchema.read(
       Paths.get("src/test/resources/include-example/first.xsd"))
     val expectedSchema = buildSchema(
-      struct("basket",
-        structArray("entry",
-          field("key"),
-          field("value"))))
+      field("basket",
+        struct(
+          structArray("entry",
+            field("key"),
+            field("value"))), nullable = false))
     assert(expectedSchema === parsedSchema)
   }
 

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -45,7 +45,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
           field("value"))))
     assert(expectedSchema === parsedSchema)
   }
-  
+
   test("Test schema types and attributes") {
     val parsedSchema = XSDToSchema.read(
       Paths.get("src/test/resources/catalog.xsd"))


### PR DESCRIPTION
Closes #474 

- Fixes how QNames were looked up from the schema - did not actually work before
- Attributes were not handled in most cases; now they are
- Nullability wasn't handled correctly in many cases according to minOccurs; now should be
- Refactored test code to share schema construction code