### PR TITLE
extended support for XmlSchemaComplexContentExtension in XSDToSchema.getStructField

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -23,21 +23,22 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.types._
 import org.apache.ws.commons.schema._
 import org.apache.ws.commons.schema.constants.Constants
+import scala.collection.mutable
 
 /**
-  * Utility to generate a Spark schema from an XSD. Not all XSD schemas are simple tabular schemas,
-  * so not all elements or XSDs are supported.
-  */
+ * Utility to generate a Spark schema from an XSD. Not all XSD schemas are simple tabular schemas,
+ * so not all elements or XSDs are supported.
+ */
 @Experimental
 object XSDToSchema {
   val schemaNameToStructFieldMap = collection.mutable.Map[String, StructField]()
 
   /**
-    * Reads a schema from an XSD file.
-    *
-    * @param xsdFile XSD file
-    * @return Spark-compatible schema
-    */
+   * Reads a schema from an XSD file.
+   *
+   * @param xsdFile XSD file
+   * @return Spark-compatible schema
+   */
   @Experimental
   def read(xsdFile: File): StructType = {
     val xmlSchemaCollection = new XmlSchemaCollection()
@@ -49,25 +50,26 @@ object XSDToSchema {
   }
 
   /**
-    * Reads a schema from an XSD file.
-    *
-    * @param xsdFile XSD file
-    * @return Spark-compatible schema
-    */
+   * Reads a schema from an XSD file.
+   *
+   * @param xsdFile XSD file
+   * @return Spark-compatible schema
+   */
   @Experimental
   def read(xsdFile: Path): StructType = read(xsdFile.toFile)
 
   /**
-    * Reads a schema from an XSD as a string.
-    *
-    * @param xsdString XSD as a string
-    * @return Spark-compatible schema
-    */
+   * Reads a schema from an XSD as a string.
+   *
+   * @param xsdString XSD as a string
+   * @return Spark-compatible schema
+   */
   @Experimental
   def read(xsdString: String): StructType = {
     val xmlSchema = new XmlSchemaCollection().read(new StringReader(xsdString))
     getStructType(xmlSchema)
   }
+
 
   private def getStructField(xmlSchema: XmlSchema, schemaType: XmlSchemaType): StructField = {
     schemaType match {
@@ -128,12 +130,22 @@ object XSDToSchema {
                   case attribute: XmlSchemaAttribute =>
                     val baseStructField = getBaseStructField(xmlSchema,
                       xmlSchema.getParent.getTypeByQName(attribute.getSchemaTypeName))
+                    val metaData = new MetadataBuilder()
+                      .putString("baseUri", attribute.getQName.getNamespaceURI)
+                      .build()
                     StructField(s"_${attribute.getName}", baseStructField.dataType,
-                      attribute.getUse != XmlSchemaUse.REQUIRED)
+                      attribute.getUse != XmlSchemaUse.REQUIRED,
+                      metaData)
                 }
-                schemaNameToStructFieldMap += (schemaType.getName ->
-                  StructField(complexType.getName, StructType(baseStructField +: attributes)))
-                StructField(complexType.getName, StructType(baseStructField +: attributes))
+                val metaData = new MetadataBuilder()
+                  .putString("baseUri", complexType.getQName.getNamespaceURI)
+                  .build()
+                val structField = StructField(complexType.getName,
+                  StructType(baseStructField.dataType.asInstanceOf[StructType].fields ++
+                    attributes),
+                  metadata = metaData)
+                schemaNameToStructFieldMap += (schemaType.getName -> structField)
+                structField
             }
           case content: XmlSchemaComplexContent =>
             content.getContent match {
@@ -144,134 +156,69 @@ object XSDToSchema {
                   case attribute: XmlSchemaAttribute =>
                     val baseStructField = getBaseStructField(xmlSchema,
                       xmlSchema.getParent.getTypeByQName(attribute.getSchemaTypeName))
+                    val metaData = new MetadataBuilder()
+                      .putString("baseUri", attribute.getQName.getNamespaceURI)
+                      .build()
                     StructField(s"_${attribute.getName}", baseStructField.dataType,
-                      attribute.getUse != XmlSchemaUse.REQUIRED)
+                      attribute.getUse != XmlSchemaUse.REQUIRED,
+                      metaData)
                 }
-                schemaNameToStructFieldMap += (schemaType.getName ->
-                  StructField(complexType.getName, StructType(baseStructField +: attributes)))
-                StructField(complexType.getName, StructType(baseStructField +: attributes))
-              
+                val metaData = new MetadataBuilder()
+                  .putString("baseUri", complexType.getQName.getNamespaceURI)
+                  .build()
+                val structField = StructField(complexType.getName,
+                  StructType(baseStructField.dataType.asInstanceOf[StructType].fields ++
+                    attributes),
+                  metadata = metaData)
+                schemaNameToStructFieldMap += (schemaType.getName -> structField)
+                structField
+
               case extension: XmlSchemaComplexContentExtension =>
                 val baseStructField = getBaseStructField(xmlSchema,
                   xmlSchema.getParent.getTypeByQName(extension.getBaseTypeName))
-                val childFields =
-                  extension.getParticle match {
-                    // xs:all
-                    case all: XmlSchemaAll =>
-                      all.getItems.asScala.map {
-                        case element: XmlSchemaElement =>
-                          val baseStructField = getBaseStructField(xmlSchema,
-                            element.getSchemaType)
-                          val nullable = element.getMinOccurs == 0
-                          if (element.getMaxOccurs == 1) {
-                            StructField(element.getName, baseStructField.dataType, nullable)
-                          } else {
-                            StructField(element.getName,
-                              ArrayType(baseStructField.dataType), nullable)
-                          }
-                      }
-                    // xs:choice
-                    case choice: XmlSchemaChoice =>
-                      choice.getItems.asScala.map { case element: XmlSchemaElement =>
-                        val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
-                        val nullable = element.getMinOccurs == 0
-                        if (element.getMaxOccurs == 1) {
-                          StructField(element.getName, baseStructField.dataType, nullable)
-                        } else {
-                          StructField(element.getName,
-                            ArrayType(baseStructField.dataType), nullable)
-                        }
-                      }
-                    // xs:sequence
-                    case sequence: XmlSchemaSequence =>
-                      // flatten xs:choice nodes
-                      sequence.getItems.asScala.flatMap { member: XmlSchemaSequenceMember =>
-                        member match {
-                          case choice: XmlSchemaChoice =>
-                            choice.getItems.asScala.map(e =>
-                              (e.asInstanceOf[XmlSchemaElement], true))
-                          case element: XmlSchemaElement =>
-                            Seq((element, element.getMinOccurs == 0))
-                        }
-                      }.map { case (element: XmlSchemaElement, nullable) =>
-                        val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
-                        if (element.getMaxOccurs == 1) {
-                          StructField(element.getName, baseStructField.dataType, nullable)
-                        } else {
-                          StructField(element.getName,
-                            ArrayType(baseStructField.dataType), nullable)
-                        }
-                      }
-                  }
+                val childFields = getChildFields(xmlSchema, extension.getParticle)
                 val attributes = extension.getAttributes.asScala.map {
                   case attribute: XmlSchemaAttribute =>
                     val baseStructField = getBaseStructField(xmlSchema,
                       xmlSchema.getParent.getTypeByQName(attribute.getSchemaTypeName))
+                    val metaData = new MetadataBuilder()
+                      .putString("baseUri", attribute.getQName.getNamespaceURI)
+                      .build()
                     StructField(s"_${attribute.getName}", baseStructField.dataType,
-                      attribute.getUse != XmlSchemaUse.REQUIRED)
+                      attribute.getUse != XmlSchemaUse.REQUIRED,
+                      metaData)
                 }
-                schemaNameToStructFieldMap += (schemaType.getName ->
-                  StructField(schemaType.getName,
-                    StructType(baseStructField +: (childFields ++ attributes))))
-                StructField(schemaType.getName,
-                  StructType(baseStructField +: (childFields ++ attributes)))
+                val metaData = new MetadataBuilder()
+                  .putString("baseUri", schemaType.getQName.getNamespaceURI)
+                  .build()
+                val structField = StructField(schemaType.getName,
+                  StructType(baseStructField.dataType.asInstanceOf[StructType].fields ++
+                    (childFields ++ attributes)),
+                  metadata = metaData)
+                schemaNameToStructFieldMap += (schemaType.getName -> structField)
+                structField
             }
           case null => {
-            val childFields =
-              complexType.getParticle match {
-                // xs:all
-                case all: XmlSchemaAll =>
-                  all.getItems.asScala.map {
-                    case element: XmlSchemaElement =>
-                      val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
-                      val nullable = element.getMinOccurs == 0
-                      if (element.getMaxOccurs == 1) {
-                        StructField(element.getName, baseStructField.dataType, nullable)
-                      } else {
-                        StructField(element.getName,
-                          ArrayType(baseStructField.dataType), nullable)
-                      }
-                  }
-                // xs:choice
-                case choice: XmlSchemaChoice =>
-                  choice.getItems.asScala.map { case element: XmlSchemaElement =>
-                    val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
-                    val nullable = element.getMinOccurs == 0
-                    if (element.getMaxOccurs == 1) {
-                      StructField(element.getName, baseStructField.dataType, nullable)
-                    } else {
-                      StructField(element.getName, ArrayType(baseStructField.dataType), nullable)
-                    }
-                  }
-                // xs:sequence
-                case sequence: XmlSchemaSequence =>
-                  // flatten xs:choice nodes
-                  sequence.getItems.asScala.flatMap { member: XmlSchemaSequenceMember =>
-                    member match {
-                      case choice: XmlSchemaChoice =>
-                        choice.getItems.asScala.map(e => (e.asInstanceOf[XmlSchemaElement], true))
-                      case element: XmlSchemaElement => Seq((element, element.getMinOccurs == 0))
-                    }
-                  }.map { case (element: XmlSchemaElement, nullable) =>
-                    val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
-                    if (element.getMaxOccurs == 1) {
-
-                      StructField(element.getName, baseStructField.dataType, nullable)
-                    } else {
-                      StructField(element.getName, ArrayType(baseStructField.dataType), nullable)
-                    }
-                  }
-              }
+            val childFields = getChildFields(xmlSchema, complexType.getParticle)
             val attributes = complexType.getAttributes.asScala.map {
               case attribute: XmlSchemaAttribute =>
                 val baseStructField = getBaseStructField(xmlSchema,
                   xmlSchema.getParent.getTypeByQName(attribute.getSchemaTypeName))
+                val metaData = new MetadataBuilder()
+                  .putString("baseUri", attribute.getQName.getNamespaceURI)
+                  .build()
                 StructField(s"_${attribute.getName}", baseStructField.dataType,
-                  attribute.getUse != XmlSchemaUse.REQUIRED)
+                  attribute.getUse != XmlSchemaUse.REQUIRED,
+                  metaData)
             }
-            schemaNameToStructFieldMap += (schemaType.getName ->
-              StructField(complexType.getName, StructType(childFields ++ attributes)))
-            StructField(complexType.getName, StructType(childFields ++ attributes))
+            val metaData = new MetadataBuilder()
+              .putString("baseUri", complexType.getQName.getNamespaceURI)
+              .build()
+            val structField = StructField(complexType.getName,
+              StructType(childFields ++ attributes),
+              metadata = metaData)
+            schemaNameToStructFieldMap += (schemaType.getName -> structField)
+            structField
           }
         }
       case unsupported =>
@@ -280,13 +227,75 @@ object XSDToSchema {
   }
 
   private def getBaseStructField(xmlSchema: XmlSchema, schemaType: XmlSchemaType): StructField = {
-    if (schemaNameToStructFieldMap.contains(schemaType.getName)){
-      return schemaNameToStructFieldMap.getOrElse(schemaType.getName, null);
-    } else {
-      val schemaType1 = getStructField(xmlSchema, schemaType)
-      return schemaType1
+    schemaNameToStructFieldMap.getOrElse(schemaType.getName,
+      getStructField(xmlSchema, schemaType))
+  }
+
+  private def getChildFields(xmlSchema: XmlSchema,
+                             varType: XmlSchemaParticle): mutable.Buffer[StructField] = {
+    varType match {
+      // xs:all
+      case all: XmlSchemaAll =>
+        all.getItems.asScala.map {
+          case element: XmlSchemaElement =>
+            val baseStructField = getBaseStructField(xmlSchema,
+              element.getSchemaType)
+            val nullable = element.getMinOccurs == 0
+            val metaData = new MetadataBuilder()
+              .putString("baseUri", element.getQName.getNamespaceURI)
+              .build()
+            if (element.getMaxOccurs == 1) {
+              StructField(element.getName, baseStructField.dataType, nullable,
+                metaData)
+            } else {
+              StructField(element.getName,
+                ArrayType(baseStructField.dataType), nullable,
+                metaData)
+            }
+        }
+      // xs:choice
+      case choice: XmlSchemaChoice =>
+        choice.getItems.asScala.map { case element: XmlSchemaElement =>
+          val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
+          val nullable = element.getMinOccurs == 0
+          val metaData = new MetadataBuilder()
+            .putString("baseUri", element.getQName.getNamespaceURI)
+            .build()
+          if (element.getMaxOccurs == 1) {
+            StructField(element.getName, baseStructField.dataType, nullable,
+              metaData)
+          } else {
+            StructField(element.getName,
+              ArrayType(baseStructField.dataType), nullable, metaData)
+          }
+        }
+      // xs:sequence
+      case sequence: XmlSchemaSequence =>
+        // flatten xs:choice nodes
+        sequence.getItems.asScala.flatMap { member: XmlSchemaSequenceMember =>
+          member match {
+            case choice: XmlSchemaChoice =>
+              choice.getItems.asScala.map(e =>
+                (e.asInstanceOf[XmlSchemaElement], true))
+            case element: XmlSchemaElement =>
+              Seq((element, element.getMinOccurs == 0))
+          }
+        }.map { case (element: XmlSchemaElement, nullable) =>
+          val baseStructField = getBaseStructField(xmlSchema, element.getSchemaType)
+          val metaData = new MetadataBuilder()
+            .putString("baseUri", element.getQName.getNamespaceURI)
+            .build()
+          if (element.getMaxOccurs == 1) {
+            StructField(element.getName, baseStructField.dataType, nullable,
+              metaData)
+          } else {
+            StructField(element.getName,
+              ArrayType(baseStructField.dataType), nullable, metaData)
+          }
+        }
     }
   }
+
   private def getStructType(xmlSchema: XmlSchema): StructType = {
     val (qName, schemaElement) = xmlSchema.getElements.asScala.head
     val schemaType = schemaElement.getSchemaType


### PR DESCRIPTION
Extended support for XmlSchemaComplexContentExtension and changed the way extension elements were being added to baseStructField