### PR TITLE
FIX #485 Fix Timestamp to conform to XML Spec

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -15,6 +15,8 @@
  */
 package com.databricks.spark.xml.parsers
 
+import java.time.format.DateTimeFormatter
+
 import javax.xml.stream.XMLStreamWriter
 
 import scala.collection.Map
@@ -76,7 +78,7 @@ private[xml] object StaxXmlGenerator {
     def writeElement(dt: DataType, v: Any): Unit = (dt, v) match {
       case (_, null) | (NullType, _) => writer.writeCharacters(options.nullValue)
       case (StringType, v: String) => writer.writeCharacters(v)
-      case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(v.toString)
+      case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(DateTimeFormatter.ISO_INSTANT.format(v.toInstant()))
       case (IntegerType, v: Int) => writer.writeCharacters(v.toString)
       case (ShortType, v: Short) => writer.writeCharacters(v.toString)
       case (FloatType, v: Float) => writer.writeCharacters(v.toString)

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.xml.util
+
+import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
+
+import java.sql.Date
+import java.sql.Timestamp
+import java.time.{ZoneId, ZonedDateTime}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+
+import org.apache.commons.io.FileUtils
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+case class KnownData(
+    booleanDatum: Boolean,
+    dateDatum: Date,
+    decimalDatum: Decimal,
+    doubleDatum: Double,
+    integerDatum: Integer,
+    longDatum: Long,
+    stringDatum: String,
+    timeDatum: String,
+    timestampDatum: Timestamp,
+    nullDatum: Null
+)
+
+final class StaxXmlGeneratorSuite extends AnyFunSuite with BeforeAndAfterAll {
+  val dataset = Seq(
+      KnownData(booleanDatum=true, dateDatum=Date.valueOf("2016-12-18"), decimalDatum=Decimal(54.321, 10, 3), doubleDatum=42.4242, integerDatum=17, longDatum=1520828868, stringDatum="test,breakdelimiter", timestampDatum=Timestamp.from(ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant), timeDatum="12:34:56", nullDatum=null),
+      KnownData(booleanDatum=false, dateDatum=Date.valueOf("2016-12-19"), decimalDatum=Decimal(12.345, 10, 3), doubleDatum=21.2121, integerDatum=34, longDatum=1520828123, stringDatum="breakdelimiter,test", timestampDatum=Timestamp.from(ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0, ZoneId.of("America/New_York")).toInstant), timeDatum="23:45:16", nullDatum=null)
+  )
+  val targetFile = FileUtils.getTempDirectoryPath() + "roundtrip.xml"
+
+  private lazy val spark: SparkSession = {
+    // It is intentionally a val to allow import implicits.
+    SparkSession.builder().
+      master("local[2]").
+      appName("XmlSuite").
+      config("spark.ui.enabled", false).
+      getOrCreate()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.deleteQuietly(new java.io.File(targetFile))
+    try {
+      spark.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("write/read roundtrip") {
+    import spark.implicits._
+    val df = dataset.toDF.orderBy("booleanDatum")
+    df.write.format("xml").save(targetFile);
+    val newDf = spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum");
+    assert(df.collect.deep == newDf.collect.deep)
+  }
+
+}


### PR DESCRIPTION
We are currently (https://github.com/databricks/spark-xml/blob/master/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala#L79) relying on the default java.sql.Timestamp format (https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html#toString--) which formats timestamp objects in local time whereas the spec https://www.w3.org/TR/xmlschema-2/#dateTime indicates everything should be in UTC.

As the spec supports the inclusion of the timezone 'Z' we should be explicit so anyone manually reading a file can also understand the accurate timestamp.

See https://github.com/databricks/spark-xml/issues/485