### PR TITLE
Allow multiple root elements in XSD

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -33,6 +33,9 @@ object XSDToSchema {
 
   /**
    * Reads a schema from an XSD file.
+   * Note that if the schema consists of one complex parent type which you want to use as
+   * the row tag schema, then you will need to extract the schema of the single resulting
+   * struct in the resulting StructType, and use its StructType as your schema.
    *
    * @param xsdFile XSD file
    * @return Spark-compatible schema
@@ -49,6 +52,9 @@ object XSDToSchema {
 
   /**
    * Reads a schema from an XSD file.
+   * Note that if the schema consists of one complex parent type which you want to use as
+   * the row tag schema, then you will need to extract the schema of the single resulting
+   * struct in the resulting StructType, and use its StructType as your schema.
    *
    * @param xsdFile XSD file
    * @return Spark-compatible schema
@@ -58,6 +64,9 @@ object XSDToSchema {
 
   /**
    * Reads a schema from an XSD as a string.
+   * Note that if the schema consists of one complex parent type which you want to use as
+   * the row tag schema, then you will need to extract the schema of the single resulting
+   * struct in the resulting StructType, and use its StructType as your schema.
    *
    * @param xsdString XSD as a string
    * @return Spark-compatible schema
@@ -192,13 +201,14 @@ object XSDToSchema {
   }
 
   private def getStructType(xmlSchema: XmlSchema): StructType = {
-    val (qName, schemaElement) = xmlSchema.getElements.asScala.head
-    val schemaType = schemaElement.getSchemaType
-    if (schemaType.isAnonymous) {
-      schemaType.setName(qName.getLocalPart)
-    }
-    val rootType = getStructField(xmlSchema, schemaType)
-    StructType(Seq(StructField(rootType.name, rootType.dataType, schemaElement.getMinOccurs == 0)))
+    StructType(xmlSchema.getElements.asScala.toSeq.map { case (qName, schemaElement) =>
+      val schemaType = schemaElement.getSchemaType
+      // if (schemaType.isAnonymous) {
+      //   schemaType.setName(qName.getLocalPart)
+      // }
+      val rootType = getStructField(xmlSchema, schemaType)
+      StructField(qName.getLocalPart, rootType.dataType, schemaElement.getMinOccurs == 0)
+    })
   }
 
 }

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -207,7 +207,7 @@ object XSDToSchema {
       //   schemaType.setName(qName.getLocalPart)
       // }
       val rootType = getStructField(xmlSchema, schemaType)
-      StructField(qName.getLocalPart, rootType.dataType, schemaElement.getMinOccurs == 0)
+      StructField(schemaElement.getName, rootType.dataType, schemaElement.getMinOccurs == 0)
     })
   }
 

--- a/src/test/resources/twoelements.xsd
+++ b/src/test/resources/twoelements.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo" type="xs:string"/>
+  <xs:element name="bar" type="xs:string"/>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -72,4 +72,10 @@ class XSDToSchemaSuite extends AnyFunSuite {
     assert(expectedSchema === parsedSchema)
   }
 
+  test("Two root elements") {
+    val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/twoelements.xsd"))
+    val expectedSchema = buildSchema(field("bar", nullable = false), field("foo", nullable = false))
+    assert(expectedSchema === parsedSchema)
+  }
+
 }


### PR DESCRIPTION
This relates to issue #484 

The XSD -> schema tool currently only pays attention to the first element in the XSD. There's no good reason not to allow multiple ones.

I also believe I fixed a possible bug in determining the element name.