### PR TITLE
Assume xs:choice elements are nullable

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -160,11 +160,10 @@ object XSDToSchema {
                 case choice: XmlSchemaChoice =>
                   choice.getItems.asScala.map { case element: XmlSchemaElement =>
                     val baseStructField = getStructField(xmlSchema, element.getSchemaType)
-                    val nullable = element.getMinOccurs == 0
                     if (element.getMaxOccurs == 1) {
-                      StructField(element.getName, baseStructField.dataType, nullable)
+                      StructField(element.getName, baseStructField.dataType, true)
                     } else {
-                      StructField(element.getName, ArrayType(baseStructField.dataType), nullable)
+                      StructField(element.getName, ArrayType(baseStructField.dataType), true)
                     }
                   }
                 // xs:sequence

--- a/src/test/resources/choice.xsd
+++ b/src/test/resources/choice.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="el">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="foo" minOccurs="0" type="xs:string"/>
+        <xs:element name="bar" minOccurs="1" type="xs:string"/>
+        <xs:element name="baz" minOccurs="2" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -39,7 +39,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
   }
 
   test("Relative path parsing") {
-    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/first.xsd"))
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/include-example/first.xsd"))
     val expectedSchema = buildSchema(
       field("basket",
         struct(

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -24,9 +24,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import com.databricks.spark.xml.TestUtils._
 
 class XSDToSchemaSuite extends AnyFunSuite {
+  
+  private val resDir = "src/test/resources"
 
   test("Basic parsing") {
-    val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/basket.xsd"))
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/basket.xsd"))
     val expectedSchema = buildSchema(
       field("basket",
         struct(
@@ -37,8 +39,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
   }
 
   test("Relative path parsing") {
-    val parsedSchema = XSDToSchema.read(
-      Paths.get("src/test/resources/include-example/first.xsd"))
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/first.xsd"))
     val expectedSchema = buildSchema(
       field("basket",
         struct(
@@ -49,8 +50,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
   }
 
   test("Test schema types and attributes") {
-    val parsedSchema = XSDToSchema.read(
-      Paths.get("src/test/resources/catalog.xsd"))
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/catalog.xsd"))
     val expectedSchema = buildSchema(
       field("catalog",
         struct(
@@ -72,8 +72,15 @@ class XSDToSchemaSuite extends AnyFunSuite {
     assert(expectedSchema === parsedSchema)
   }
 
+  test("Test xs:choice nullability") {
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/choice.xsd"))
+    val expectedSchema = buildSchema(
+      field("el", struct(field("foo"), field("bar"), field("baz")), nullable = false))
+    assert(expectedSchema === parsedSchema)
+  }
+
   test("Two root elements") {
-    val parsedSchema = XSDToSchema.read(Paths.get("src/test/resources/twoelements.xsd"))
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/twoelements.xsd"))
     val expectedSchema = buildSchema(field("bar", nullable = false), field("foo", nullable = false))
     assert(expectedSchema === parsedSchema)
   }


### PR DESCRIPTION
Closes #490 
Because only one child of an xs:choice can actually appear, those fields should be inherently nullable always.