### PR TITLE
Update to sbt 1.2.x (1.3+ not working yet); fix latent scalastyle issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 .idea/
 .idea_modules/
+.bsp/
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       env:
         - TEST_SPARK_VERSION="2.3.4"
     - env:
-        - TEST_SPARK_VERSION="2.4.6"
+        - TEST_SPARK_VERSION="2.4.7"
     - jdk: openjdk11
       env:
         - TEST_SPARK_VERSION="3.0.1"

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,8 @@ parallelExecution in Test := false
 // Skip tests during assembly
 test in assembly := {}
 
+fork := true
+
 // Prints JUnit tests in output
 testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-v"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.10")
 
 scalacOptions := Seq("-unchecked", "-deprecation")
 
-val sparkVersion = sys.props.get("spark.testVersion").getOrElse("2.4.6")
+val sparkVersion = sys.props.get("spark.testVersion").getOrElse("2.4.7")
 
 // To avoid packaging it, it's Provided below
 autoScalaLibrary := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.18
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,8 @@ libraryDependencies += "org.scalariform" %% "scalariform" % "0.2.10"
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -50,8 +50,6 @@ This file is divided into 3 sections:
 
   <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
 
-  <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
-
   <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
     <parameters>
       <parameter name="maxLineLength"><![CDATA[100]]></parameter>

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlGenerator.scala
@@ -78,7 +78,8 @@ private[xml] object StaxXmlGenerator {
     def writeElement(dt: DataType, v: Any): Unit = (dt, v) match {
       case (_, null) | (NullType, _) => writer.writeCharacters(options.nullValue)
       case (StringType, v: String) => writer.writeCharacters(v)
-      case (TimestampType, v: java.sql.Timestamp) => writer.writeCharacters(DateTimeFormatter.ISO_INSTANT.format(v.toInstant()))
+      case (TimestampType, v: java.sql.Timestamp) =>
+        writer.writeCharacters(DateTimeFormatter.ISO_INSTANT.format(v.toInstant()))
       case (IntegerType, v: Int) => writer.writeCharacters(v.toString)
       case (ShortType, v: Short) => writer.writeCharacters(v.toString)
       case (FloatType, v: Float) => writer.writeCharacters(v.toString)

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -85,9 +85,11 @@ final class StaxXmlGeneratorSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write/read roundtrip") {
     import spark.implicits._
     val df = dataset.toDF.orderBy("booleanDatum")
-    val targetFile = Files.createTempDirectory("StaxXmlGeneratorSuite").resolve("roundtrip.xml").toString
+    val targetFile =
+      Files.createTempDirectory("StaxXmlGeneratorSuite").resolve("roundtrip.xml").toString
     df.write.format("xml").save(targetFile)
-    val newDf = spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum")
+    val newDf =
+      spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum")
     assert(df.collect.deep == newDf.collect.deep)
   }
 

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.databricks.spark.xml.util
+
+package com.databricks.spark.xml.parsers
 
 import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
 
@@ -44,8 +45,31 @@ case class KnownData(
 
 final class StaxXmlGeneratorSuite extends AnyFunSuite with BeforeAndAfterAll {
   val dataset = Seq(
-      KnownData(booleanDatum=true, dateDatum=Date.valueOf("2016-12-18"), decimalDatum=Decimal(54.321, 10, 3), doubleDatum=42.4242, integerDatum=17, longDatum=1520828868, stringDatum="test,breakdelimiter", timestampDatum=Timestamp.from(ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant), timeDatum="12:34:56", nullDatum=null),
-      KnownData(booleanDatum=false, dateDatum=Date.valueOf("2016-12-19"), decimalDatum=Decimal(12.345, 10, 3), doubleDatum=21.2121, integerDatum=34, longDatum=1520828123, stringDatum="breakdelimiter,test", timestampDatum=Timestamp.from(ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0, ZoneId.of("America/New_York")).toInstant), timeDatum="23:45:16", nullDatum=null)
+      KnownData(
+        booleanDatum = true,
+        dateDatum = Date.valueOf("2016-12-18"),
+        decimalDatum = Decimal(54.321, 10, 3),
+        doubleDatum = 42.4242,
+        integerDatum = 17,
+        longDatum = 1520828868,
+        stringDatum = "test,breakdelimiter",
+        timestampDatum = Timestamp.from(
+          ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0,
+          ZoneId.of("UTC")).toInstant),
+        timeDatum = "12:34:56",
+        nullDatum = null),
+      KnownData(booleanDatum = false,
+        dateDatum = Date.valueOf("2016-12-19"),
+        decimalDatum = Decimal(12.345, 10, 3),
+        doubleDatum = 21.2121,
+        integerDatum = 34,
+        longDatum = 1520828123,
+        stringDatum = "breakdelimiter,test",
+        timestampDatum = Timestamp.from(
+          ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0,
+          ZoneId.of("America/New_York")).toInstant),
+        timeDatum = "23:45:16",
+        nullDatum = null)
   )
   val targetFile = FileUtils.getTempDirectoryPath() + "roundtrip.xml"
 
@@ -75,8 +99,8 @@ final class StaxXmlGeneratorSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write/read roundtrip") {
     import spark.implicits._
     val df = dataset.toDF.orderBy("booleanDatum")
-    df.write.format("xml").save(targetFile);
-    val newDf = spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum");
+    df.write.format("xml").save(targetFile)
+    val newDf = spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum")
     assert(df.collect.deep == newDf.collect.deep)
   }
 

--- a/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -16,12 +16,11 @@
 
 package com.databricks.spark.xml.parsers
 
+import java.nio.file.Files
 import java.sql.Date
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
-
-import org.apache.commons.io.FileUtils
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
@@ -86,7 +85,7 @@ final class StaxXmlGeneratorSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write/read roundtrip") {
     import spark.implicits._
     val df = dataset.toDF.orderBy("booleanDatum")
-    val targetFile = FileUtils.getTempDirectoryPath() + "roundtrip.xml"
+    val targetFile = Files.createTempDirectory("StaxXmlGeneratorSuite").resolve("roundtrip.xml").toString
     df.write.format("xml").save(targetFile)
     val newDf = spark.read.schema(df.schema).format("xml").load(targetFile).orderBy("booleanDatum")
     assert(df.collect.deep == newDf.collect.deep)


### PR DESCRIPTION
Not sure why, but different classpath treatment during tests in sbt 1.3 makes Spark 2.x tests fail. 
Otherwise just fixing a breakage in master while updating to at least SBT 1.2.8