### PR TITLE
Support xs:any in XSD as a 'wildcard' schema element in XML parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ When reading files the API accepts several options:
 * `wildcardColName`: Name of a column existing in the provided schema which is interpreted as a 'wildcard'.
 It must have type string or array of strings. It will match any XML child element that is not otherwise matched by the schema.
 The XML of the child becomes the string value of the column. If an array, then all unmatched elements will be returned
-as an array of strings. As its name implies, it is meant to emulate XSD's `xs:any` type. Default is `xs_any`.
+as an array of strings. As its name implies, it is meant to emulate XSD's `xs:any` type. Default is `xs_any`. New in 0.11.0.
 * `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to 
 validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. 
 Note that if the same local path is not already also visible on the executors in the cluster, then the XSD and any others 
 it depends on should be added to the Spark executors with 
 [`SparkContext.addFile`](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext@addFile(path:String):Unit).
-In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`. New in 0.8.0.
+In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`.
 
 When writing files the API accepts several options:
 
@@ -101,7 +101,7 @@ Currently it supports the shortened name usage. You can use just `xml` instead o
 
 Per above, the XML for individual rows can be validated against an XSD using `rowValidationXSDPath`.
 
-From 0.10 onwards, the utility `com.databricks.spark.xml.util.XSDToSchema` can be used to extract a Spark DataFrame
+The utility `com.databricks.spark.xml.util.XSDToSchema` can be used to extract a Spark DataFrame
 schema from _some_ XSD files. It supports only simple, complex and sequence types, only basic XSD functionality,
 and is experimental.
 
@@ -115,7 +115,7 @@ val df = spark.read.schema(schema)....xml(...)
 
 ### Parsing Nested XML
 
-Although primarily used to convert (portions of) large XML documents into a `DataFrame`, from version 0.8.0 onwards,
+Although primarily used to convert (portions of) large XML documents into a `DataFrame`,
 `spark-xml` can also parse XML in a string-valued column in an existing DataFrame with `from_xml`, in order to add
 it as a new column with parsed results as a struct.
 
@@ -458,7 +458,7 @@ val records = sc.newAPIHadoopFile(
 
 ## Building From Source
 
-This library is built with [SBT](https://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html). To build a JAR file simply run `sbt package` from the project root. The build configuration includes support for both Scala 2.11 and 2.12.
+This library is built with [SBT](https://www.scala-sbt.org/). To build a JAR file simply run `sbt package` from the project root. The build configuration includes support for both Scala 2.11 and 2.12.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ When reading files the API accepts several options:
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `charset`: Defaults to 'UTF-8' but can be set to other valid charset names
 * `ignoreSurroundingSpaces`: Defines whether or not surrounding whitespaces from values being read should be skipped. Default is false.
+* `wildcardColName`: Name of a column existing in the provided schema which is interpreted as a 'wildcard'.
+It must have type string or array of strings. It will match any XML child element that is not otherwise matched by the schema.
+The XML of the child becomes the string value of the column. If an array, then all unmatched elements will be returned
+as an array of strings. As its name implies, it is meant to emulate XSD's `xs:any` type. Default is `xs_any`.
 * `rowValidationXSDPath`: Path to an XSD file that is used to validate the XML for each row individually. Rows that fail to 
 validate are treated like parse errors as above. The XSD does not otherwise affect the schema provided, or inferred. 
 Note that if the same local path is not already also visible on the executors in the cluster, then the XSD and any others 

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -53,6 +53,8 @@ private[xml] class XmlOptions(
   val parseMode = ParseMode.fromString(parameters.getOrElse("mode", PermissiveMode.name))
   val inferSchema = parameters.get("inferSchema").map(_.toBoolean).getOrElse(true)
   val rowValidationXSDPath = parameters.get("rowValidationXSDPath").orNull
+  val wildcardColName =
+    parameters.getOrElse("wildcardColName", XmlOptions.DEFAULT_WILDCARD_COL_NAME)
 }
 
 private[xml] object XmlOptions {
@@ -62,6 +64,7 @@ private[xml] object XmlOptions {
   val DEFAULT_ROOT_TAG = "ROWS"
   val DEFAULT_CHARSET: String = StandardCharsets.UTF_8.name
   val DEFAULT_NULL_VALUE: String = null
+  val DEFAULT_WILDCARD_COL_NAME = "xs_any"
 
   def apply(parameters: Map[String, String]): XmlOptions = new XmlOptions(parameters)
 }

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -294,6 +294,10 @@ private[xml] object StaxXmlParser extends Serializable {
     convertAttributes(rootAttributes, schema, options).toSeq.foreach { case (f, v) =>
       nameToIndex.get(f).foreach { row(_) = v }
     }
+    
+    val wildcardColName = options.wildcardColName
+    val hasWildcard = schema.exists(_.name == wildcardColName)
+    
     var badRecordException: Option[Throwable] = None
 
     var shouldStop = false
@@ -325,12 +329,12 @@ private[xml] object StaxXmlParser extends Serializable {
             }
 
             case None =>
-              if (schema.exists(_.name == "xs_any")) {
+              if (hasWildcard) {
                 // Special case: there's an 'any' wildcard element that matches anything else
                 // as a string (or array of strings, to parse multiple ones)
                 val newValue = convertField(parser, StringType, options)
-                val anyIndex = schema.fieldIndex("xs_any")
-                schema("xs_any").dataType match {
+                val anyIndex = schema.fieldIndex(wildcardColName)
+                schema(wildcardColName).dataType match {
                   case StringType =>
                     row(anyIndex) = newValue
                   case ArrayType(StringType, _) =>

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -24,6 +24,8 @@ import org.apache.spark.sql.types._
 import org.apache.ws.commons.schema._
 import org.apache.ws.commons.schema.constants.Constants
 
+import com.databricks.spark.xml.XmlOptions
+
 /**
  * Utility to generate a Spark schema from an XSD. Not all XSD schemas are simple tabular schemas,
  * so not all elements or XSDs are supported.
@@ -168,7 +170,7 @@ object XSDToSchema {
                       }
                     case any: XmlSchemaAny =>
                       val dataType = if (any.getMaxOccurs > 1) ArrayType(StringType) else StringType
-                      StructField("xs_any", dataType, true)
+                      StructField(XmlOptions.DEFAULT_WILDCARD_COL_NAME, dataType, true)
                   }
                 // xs:sequence
                 case sequence: XmlSchemaSequence =>
@@ -190,7 +192,7 @@ object XSDToSchema {
                       val dataType =
                         if (any.getMaxOccurs > 1) ArrayType(StringType) else StringType
                       val nullable = any.getMinOccurs == 0
-                      Seq(StructField("xs_any", dataType, nullable))
+                      Seq(StructField(XmlOptions.DEFAULT_WILDCARD_COL_NAME, dataType, nullable))
                     }
                   }
               }

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -158,29 +158,39 @@ object XSDToSchema {
                   }
                 // xs:choice
                 case choice: XmlSchemaChoice =>
-                  choice.getItems.asScala.map { case element: XmlSchemaElement =>
-                    val baseStructField = getStructField(xmlSchema, element.getSchemaType)
-                    if (element.getMaxOccurs == 1) {
-                      StructField(element.getName, baseStructField.dataType, true)
-                    } else {
-                      StructField(element.getName, ArrayType(baseStructField.dataType), true)
-                    }
+                  choice.getItems.asScala.map {
+                    case element: XmlSchemaElement =>
+                      val baseStructField = getStructField(xmlSchema, element.getSchemaType)
+                      if (element.getMaxOccurs == 1) {
+                        StructField(element.getName, baseStructField.dataType, true)
+                      } else {
+                        StructField(element.getName, ArrayType(baseStructField.dataType), true)
+                      }
+                    case any: XmlSchemaAny =>
+                      val dataType = if (any.getMaxOccurs > 1) ArrayType(StringType) else StringType
+                      StructField("xs_any", dataType, true)
                   }
                 // xs:sequence
                 case sequence: XmlSchemaSequence =>
                   // flatten xs:choice nodes
-                  sequence.getItems.asScala.flatMap { member: XmlSchemaSequenceMember =>
-                    member match {
-                      case choice: XmlSchemaChoice =>
-                        choice.getItems.asScala.map(e => (e.asInstanceOf[XmlSchemaElement], true))
-                      case element: XmlSchemaElement => Seq((element, element.getMinOccurs == 0))
-                    }
-                  }.map { case (element: XmlSchemaElement, nullable) =>
-                    val baseStructField = getStructField(xmlSchema, element.getSchemaType)
-                    if (element.getMaxOccurs == 1) {
-                      StructField(element.getName, baseStructField.dataType, nullable)
-                    } else {
-                      StructField(element.getName, ArrayType(baseStructField.dataType), nullable)
+                  sequence.getItems.asScala.flatMap { _ match {
+                    case choice: XmlSchemaChoice =>
+                      choice.getItems.asScala.map { e => 
+                        val xme = e.asInstanceOf[XmlSchemaElement]
+                        val baseType = getStructField(xmlSchema, xme.getSchemaType).dataType
+                        val dataType = if (xme.getMaxOccurs > 1) ArrayType(baseType) else baseType
+                        StructField(xme.getName, dataType, true)
+                      }
+                    case e: XmlSchemaElement =>
+                      val baseType = getStructField(xmlSchema, e.getSchemaType).dataType
+                      val dataType = if (e.getMaxOccurs > 1) ArrayType(baseType) else baseType
+                      val nullable = e.getMinOccurs == 0
+                      Seq(StructField(e.getName, dataType, nullable))
+                    case any: XmlSchemaAny =>
+                      val dataType =
+                        if (any.getMaxOccurs > 1) ArrayType(StringType) else StringType
+                      val nullable = any.getMinOccurs == 0
+                      Seq(StructField("xs_any", dataType, nullable))
                     }
                   }
               }

--- a/src/test/resources/xsany.xsd
+++ b/src/test/resources/xsany.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="foo">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="bar">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="baz">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="1" maxOccurs="2"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="bing">
+          <xs:complexType>
+            <xs:choice>
+              <xs:any minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.xml.util
 
 import java.nio.file.Paths
 
-import org.apache.spark.sql.types.FloatType
+import org.apache.spark.sql.types.{ArrayType, FloatType, StringType}
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.databricks.spark.xml.TestUtils._
@@ -82,6 +82,31 @@ class XSDToSchemaSuite extends AnyFunSuite {
   test("Two root elements") {
     val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/twoelements.xsd"))
     val expectedSchema = buildSchema(field("bar", nullable = false), field("foo", nullable = false))
+    assert(expectedSchema === parsedSchema)
+  }
+  
+  test("xs:any schema") {
+    val parsedSchema = XSDToSchema.read(Paths.get(s"${resDir}/xsany.xsd"))
+    val expectedSchema = buildSchema(
+      field("root",
+        struct(
+          field("foo",
+            struct(
+              field("xs_any", nullable = true)),
+            nullable = false),
+          field("bar",
+            struct(
+              field("xs_any", nullable = false)),
+            nullable = false),
+          field("baz",
+            struct(
+              field("xs_any", ArrayType(StringType), nullable = false)),
+            nullable = false),
+          field("bing",
+            struct(
+              field("xs_any", nullable = true)),
+            nullable = false)),
+        nullable = false))
     assert(expectedSchema === parsedSchema)
   }
 


### PR DESCRIPTION
See https://github.com/databricks/spark-xml/issues/480

This attempts to support a special 'wildcard' schema element, called by default "xs_any", that will match any unmatched XML elements in a node, and treat them as strings containing the raw XML content. If it's a string, it will match one element. If it's an array of strings, it will match all of them.

This provides a natural interpretation of "xs:any" in XSDs then.