### PR TITLE
Add option to ignore namespace on elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note that if the same local path is not already also visible on the executors in
 it depends on should be added to the Spark executors with 
 [`SparkContext.addFile`](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext@addFile(path:String):Unit).
 In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`.
-* `ignoreNamespace`: If true, namespaces prefixes on XML elements are ignored. Tags `<abc:author>` and `<def:author>` would,
+* `ignoreNamespace`: If true, namespaces prefixes on XML elements and attributes are ignored. Tags `<abc:author>` and `<def:author>` would,
 for example, be treated as if both are just `<author>`. Note that, at the moment, namespaces cannot be ignored on the
 `rowTag` element, only its children. Note that XML parsing is in general not namespace-aware even if `false`.
 Defaults to `false`. New in 0.11.0.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Note that if the same local path is not already also visible on the executors in
 it depends on should be added to the Spark executors with 
 [`SparkContext.addFile`](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext@addFile(path:String):Unit).
 In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` and pass just `"bar.xsd"` as `rowValidationXSDPath`.
+* `ignoreNamespace`: If true, namespaces prefixes on XML elements are ignored. Tags `<abc:author>` and `<def:author>` would,
+for example, be treated as if both are just `<author>`. Note that, at the moment, namespaces cannot be ignored on the
+`rowTag` element, only its children. Note that XML parsing is in general not namespace-aware even if `false`.
+Defaults to `false`. New in 0.11.0.
 
 When writing files the API accepts several options:
 

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -55,6 +55,7 @@ private[xml] class XmlOptions(
   val rowValidationXSDPath = parameters.get("rowValidationXSDPath").orNull
   val wildcardColName =
     parameters.getOrElse("wildcardColName", XmlOptions.DEFAULT_WILDCARD_COL_NAME)
+  val ignoreNamespace = parameters.get("ignoreNamespace").map(_.toBoolean).getOrElse(false)
 }
 
 private[xml] object XmlOptions {

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -207,14 +207,7 @@ private[xml] object StaxXmlParser extends Serializable {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          val localPart = e.getName.getLocalPart
-          // Ignore namespace prefix up to last : if configured
-          val field = if (options.ignoreNamespace) {
-            localPart.split(":").last
-          } else {
-            localPart
-          }
-          keys += field
+          keys += StaxXmlParserUtils.getName(e.asStartElement.getName, options)
           values += convertField(parser, valueType, options)
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
@@ -312,13 +305,7 @@ private[xml] object StaxXmlParser extends Serializable {
       parser.nextEvent match {
         case e: StartElement => try {
           val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
-          val localPart = e.asStartElement.getName.getLocalPart
-          // Ignore namespace prefix up to last : if configured
-          val field = if (options.ignoreNamespace) {
-            localPart.split(":").last
-          } else {
-            localPart
-          }
+          val field = StaxXmlParserUtils.getName(e.asStartElement.getName, options)
 
           nameToIndex.get(field) match {
             case Some(index) => schema(index).dataType match {

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -207,7 +207,14 @@ private[xml] object StaxXmlParser extends Serializable {
     while (!shouldStop) {
       parser.nextEvent match {
         case e: StartElement =>
-          keys += e.getName.getLocalPart
+          val localPart = e.getName.getLocalPart
+          // Ignore namespace prefix up to last : if configured
+          val field = if (options.ignoreNamespace) {
+            localPart.split(":").last
+          } else {
+            localPart
+          }
+          keys += field
           values += convertField(parser, valueType, options)
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
@@ -305,7 +312,13 @@ private[xml] object StaxXmlParser extends Serializable {
       parser.nextEvent match {
         case e: StartElement => try {
           val attributes = e.getAttributes.asScala.map(_.asInstanceOf[Attribute]).toArray
-          val field = e.asStartElement.getName.getLocalPart
+          val localPart = e.asStartElement.getName.getLocalPart
+          // Ignore namespace prefix up to last : if configured
+          val field = if (options.ignoreNamespace) {
+            localPart.split(":").last
+          } else {
+            localPart
+          }
 
           nameToIndex.get(field) match {
             case Some(index) => schema(index).dataType match {

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -219,13 +219,7 @@ private[xml] object InferSchema {
             case dt: DataType => dt
           }
           // Add the field and datatypes so that we can check if this is ArrayType.
-          val localPart = e.asStartElement.getName.getLocalPart
-          // Ignore namespace prefix up to last : if configured
-          val field = if (options.ignoreNamespace) {
-            localPart.split(":").last
-          } else {
-            localPart
-          }
+          val field = StaxXmlParserUtils.getName(e.asStartElement.getName, options)
           val dataTypes = nameToDataType.getOrElse(field, ArrayBuffer.empty[DataType])
           dataTypes += inferredType
           nameToDataType += (field -> dataTypes)

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -219,7 +219,13 @@ private[xml] object InferSchema {
             case dt: DataType => dt
           }
           // Add the field and datatypes so that we can check if this is ArrayType.
-          val field = e.asStartElement.getName.getLocalPart
+          val localPart = e.asStartElement.getName.getLocalPart
+          // Ignore namespace prefix up to last : if configured
+          val field = if (options.ignoreNamespace) {
+            localPart.split(":").last
+          } else {
+            localPart
+          }
           val dataTypes = nameToDataType.getOrElse(field, ArrayBuffer.empty[DataType])
           dataTypes += inferredType
           nameToDataType += (field -> dataTypes)

--- a/src/test/resources/books-namespaces.xml
+++ b/src/test/resources/books-namespaces.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<catalog xmlns:abc="abc" xmlns:def="def">
+   <book id="bk101" >
+      <abc:author>Gambardella, Matthew</abc:author>
+   </book>
+   <book id="bk102">
+      <def:author>Ralls, Kim</def:author>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+   </book>
+</catalog>

--- a/src/test/resources/books-namespaces.xml
+++ b/src/test/resources/books-namespaces.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <catalog xmlns:abc="abc" xmlns:def="def">
-   <book id="bk101" >
+   <book abc:id="bk101" >
       <abc:author>Gambardella, Matthew</abc:author>
    </book>
-   <book id="bk102">
+   <book def:id="bk102">
       <def:author>Ralls, Kim</def:author>
    </book>
    <book id="bk103">

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -49,6 +49,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   private val booksComplicatedFile = resDir + "books-complicated.xml"
   private val booksComplicatedFileNullAttribute =
     resDir + "books-complicated-null-attribute.xml"
+  private val booksNamespaceFile = resDir + "books-namespaces.xml"
   private val carsFile = resDir + "cars.xml"
   private val carsFile8859 = resDir + "cars-iso-8859-1.xml"
   private val carsFileGzip = resDir + "cars.xml.gz"
@@ -1282,6 +1283,14 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
       Files.list(xmlPath).iterator.asScala.filter(_.getFileName.toString.startsWith("part-")).next
     val firstLine = Source.fromFile(xmlFile.toFile).getLines.next
     assert(firstLine === "<root foo=\"bar\" bing=\"baz\">")
+  }
+
+  test("test ignoreNamespace") {
+    val results = spark.read
+      .option("rowTag", "book")
+      .option("ignoreNamespace", true)
+      .xml(booksNamespaceFile)
+    assert(results.filter("author IS NOT NULL").count() === 3)
   }
 
 }

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1291,6 +1291,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
       .option("ignoreNamespace", true)
       .xml(booksNamespaceFile)
     assert(results.filter("author IS NOT NULL").count() === 3)
+    assert(results.filter("_id IS NOT NULL").count() === 3)
   }
 
 }


### PR DESCRIPTION
This adds a new `ignoreNamespace` parameter that will disregard namespace prefixes on elements (besides the root tag)
Closes #168 