### PR TITLE
Use Text.toString to get Strings from XmlInputFormat

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -46,7 +46,7 @@ private[xml] object XmlFile {
     context.newAPIHadoopFile(location,
       classOf[XmlInputFormat],
       classOf[LongWritable],
-      classOf[Text]).map { case (_, text) => new String(text.getBytes, 0, text.getLength, charset) }
+      classOf[Text]).map { case (_, text) => text.toString }
   }
 
   /**


### PR DESCRIPTION
Closes #510 
Use Text.toString to retrieve String from XmlInputFormat. This ensures that it isn't treated as UTF-8 when that isn't the configured encoding.