### PR TITLE
Fix parsing of array-valued struct field with an optional child element; misparsed when struct element is entirely empty

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -174,7 +174,10 @@ private[xml] object StaxXmlParser extends Serializable {
           // Otherwise, ignore this character element, and continue parsing the following complex
           // structure
           parser.next
-          convertObject(parser, st, options)
+          parser.peek match {
+            case _: EndElement => null // no struct here at all; done
+            case _ => convertObject(parser, st, options)
+          }
         }
       case (c: Characters, _: DataType) if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide

--- a/src/test/resources/struct_with_optional_child.xml
+++ b/src/test/resources/struct_with_optional_child.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<Foo>
+    <Bar bing="123">
+    </Bar>
+    <Bar bing="345">
+        <Baz/>
+    </Bar>
+</Foo>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -90,6 +90,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   private val unclosedTag = resDir + "unclosed_tag.xml"
   private val whitespaceError = resDir + "whitespace_error.xml"
   private val mapAttribute = resDir + "map-attribute.xml"
+  private val structWithOptChild = resDir + "struct_with_optional_child.xml"
 
   private val booksTag = "book"
   private val booksRootTag = "books"
@@ -1308,6 +1309,11 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(map.contains("_measurementType"))
     assert(map.contains("M1"))
     assert(map.contains("M2"))
+  }
+
+  test("StructType with missing optional StructType child") {
+    val df = spark.read.option("rowTag", "Foo").xml(structWithOptChild)
+    assert(df.selectExpr("SIZE(Bar)").collect().head.getInt(0) === 2)
   }
 
   private def getLines(path: Path): Seq[String] = {


### PR DESCRIPTION
See #513 ; closes #513