### PR TITLE
Add dateFormat, timestampFormat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ In this case, to use local XSD `/foo/bar.xsd`, call `addFile("/foo/bar.xsd")` an
 for example, be treated as if both are just `<author>`. Note that, at the moment, namespaces cannot be ignored on the
 `rowTag` element, only its children. Note that XML parsing is in general not namespace-aware even if `false`.
 Defaults to `false`. New in 0.11.0.
+* `timestampFormat`: Specifies an additional timestamp format that will be tried when parsing values as `TimestampType` 
+columns. The format is specified as described in [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+Defaults to try several formats, including [ISO_INSTANT](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT),
+including variations with offset timezones or no timezone (defaults to UTC). New in 0.12.0.  
+* `dateFormat`: Specifies an additional timestamp format that will be tried when parsing values as `DateType` 
+columns. The format is specified as described in [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+Defaults to [ISO_DATE](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_DATE). New in 0.12.0.
 
 When writing files the API accepts several options:
 
@@ -98,6 +105,12 @@ When writing files the API accepts several options:
 * `attributePrefix`: The prefix for attributes so that we can differentiating attributes and elements. This will be the prefix for field names. Default is `_`.
 * `valueTag`: The tag used for the value when there are attributes in the element having no child. Default is `_VALUE`.
 * `compression`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
+* `timestampFormat`: Controls the format used to write `TimestampType` format columns.
+The format is specified as described in [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+Defaults to [ISO_INSTANT](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT). New in 0.12.0.
+* `dateFormat`: Controls the format used to write `DateType` format columns.
+The format is specified as described in [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html).
+Defaults to [ISO_DATE](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_DATE). New in 0.12.0.
 
 Currently it supports the shortened name usage. You can use just `xml` instead of `com.databricks.spark.xml`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,8 @@ mimaBinaryIssueFilters ++= {
     exclude[DirectMissingMethodProblem](
       "com.databricks.spark.xml.util.TypeCast.supportedXmlTimestampFormatters"),
     exclude[DirectMissingMethodProblem](
-      "com.databricks.spark.xml.util.TypeCast.parseXmlTimestamp")
+      "com.databricks.spark.xml.util.TypeCast.parseXmlTimestamp"),
+    exclude[DirectMissingMethodProblem](
+      "com.databricks.spark.xml.util.TypeCast.isTimestamp")
   )
 }

--- a/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlOptions.scala
@@ -56,6 +56,8 @@ private[xml] class XmlOptions(
   val wildcardColName =
     parameters.getOrElse("wildcardColName", XmlOptions.DEFAULT_WILDCARD_COL_NAME)
   val ignoreNamespace = parameters.get("ignoreNamespace").map(_.toBoolean).getOrElse(false)
+  val timestampFormat = parameters.get("timestampFormat")
+  val dateFormat = parameters.get("dateFormat")
 }
 
 private[xml] object XmlOptions {

--- a/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/InferSchema.scala
@@ -118,8 +118,8 @@ private[xml] object InferSchema {
         case v if isInteger(v) => IntegerType
         case v if isDouble(v) => DoubleType
         case v if isBoolean(v) => BooleanType
-        case v if isTimestamp(v) => TimestampType
-        case v if isDate(v) => DateType
+        case v if isTimestamp(v, options) => TimestampType
+        case v if isDate(v, options) => DateType
         case _ => StringType
       }
     } else {

--- a/src/test/resources/date.xml
+++ b/src/test/resources/date.xml
@@ -1,4 +1,5 @@
 <book>
     <author>John Smith</author>
-    <date>2021-01-01</date>
+    <date>2021-02-01</date>
+    <date2>02-01-2021</date2>
 </book>

--- a/src/test/resources/time.xml
+++ b/src/test/resources/time.xml
@@ -1,0 +1,5 @@
+<book>
+    <author>John Smith</author>
+    <time>2011-12-03T10:15:30Z</time>
+    <time2>12-03-2011 10:15:30 PST</time2>
+</book>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1298,19 +1298,64 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("Test date parsing") {
-    val schema = buildSchema(field("author"), field("date", DateType))
+    val schema = buildSchema(field("author"), field("date", DateType), field("date2", StringType))
     val df = spark.read
       .option("rowTag", "book")
       .schema(schema)
       .xml(resDir + "date.xml")
-    assert(df.collect().head.getAs[Date](1).toString === "2021-01-01")
+    assert(df.collect().head.getAs[Date](1).toString === "2021-02-01")
   }
 
   test("Test date type inference") {
     val df = spark.read
       .option("rowTag", "book")
       .xml(resDir + "date.xml")
-    assert(df.dtypes(1) === ("date", "DateType"))
+    val expectedSchema =
+      buildSchema(field("author"), field("date", DateType), field("date2", StringType))
+    assert(df.schema === expectedSchema)
+    assert(df.collect().head.getAs[Date](1).toString === "2021-02-01")
+  }
+
+  test("Test timestamp parsing") {
+    val schema =
+      buildSchema(field("author"), field("time", TimestampType), field("time2", StringType))
+    val df = spark.read
+      .option("rowTag", "book")
+      .schema(schema)
+      .xml(resDir + "time.xml")
+    assert(df.collect().head.getAs[Timestamp](1).toString === "2011-12-03 04:15:30.0")
+  }
+
+  test("Test timestamp type inference") {
+    val df = spark.read
+      .option("rowTag", "book")
+      .xml(resDir + "time.xml")
+    val expectedSchema =
+      buildSchema(field("author"), field("time", TimestampType), field("time2", StringType))
+    assert(df.schema === expectedSchema)
+    assert(df.collect().head.getAs[Timestamp](1).toString === "2011-12-03 04:15:30.0")
+  }
+
+  test("Test dateFormat") {
+    val df = spark.read
+      .option("rowTag", "book")
+      .option("dateFormat", "MM-dd-yyyy")
+      .xml(resDir + "date.xml")
+    val expectedSchema =
+      buildSchema(field("author"), field("date", DateType), field("date2", DateType))
+    assert(df.schema === expectedSchema)
+    assert(df.collect().head.getAs[Date](2).toString === "2021-02-01")
+  }
+
+  test("Test timestampFormat") {
+    val df = spark.read
+      .option("rowTag", "book")
+      .option("timestampFormat", "MM-dd-yyyy HH:mm:ss z")
+      .xml(resDir + "time.xml")
+    val expectedSchema =
+      buildSchema(field("author"), field("time", TimestampType), field("time2", TimestampType))
+    assert(df.schema === expectedSchema)
+    assert(df.collect().head.getAs[Timestamp](2).toString === "2011-12-03 12:15:30.0")
   }
 
   private def getLines(path: Path): Seq[String] = {

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -48,6 +48,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
       master("local[2]").
       appName("XmlSuite").
       config("spark.ui.enabled", false).
+      config("spark.sql.session.timeZone", "UTC").
       getOrCreate()
   }
   private var tempDir: Path = _

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1324,7 +1324,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
       .option("rowTag", "book")
       .schema(schema)
       .xml(resDir + "time.xml")
-    assert(df.collect().head.getAs[Timestamp](1).toString === "2011-12-03 04:15:30.0")
+    assert(df.collect().head.getAs[Timestamp](1).getTime === 1322907330000L)
   }
 
   test("Test timestamp type inference") {
@@ -1334,7 +1334,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     val expectedSchema =
       buildSchema(field("author"), field("time", TimestampType), field("time2", StringType))
     assert(df.schema === expectedSchema)
-    assert(df.collect().head.getAs[Timestamp](1).toString === "2011-12-03 04:15:30.0")
+    assert(df.collect().head.getAs[Timestamp](1).getTime === 1322907330000L)
   }
 
   test("Test dateFormat") {
@@ -1356,7 +1356,7 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     val expectedSchema =
       buildSchema(field("author"), field("time", TimestampType), field("time2", TimestampType))
     assert(df.schema === expectedSchema)
-    assert(df.collect().head.getAs[Timestamp](2).toString === "2011-12-03 12:15:30.0")
+    assert(df.collect().head.getAs[Timestamp](2).getTime === 1322936130000L)
   }
 
   private def getLines(path: Path): Seq[String] = {

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -155,7 +155,7 @@ final class TypeCastSuite extends AnyFunSuite {
     assert(TypeCast.isLong("10"))
     assert(TypeCast.isDouble("+10.1"))
     val timestamp = "2015-01-01 00:00:00"
-    assert(TypeCast.isTimestamp(timestamp))
+    assert(TypeCast.isTimestamp(timestamp, new XmlOptions()))
   }
 
   test("Float and Double Types are cast correctly with Locale") {


### PR DESCRIPTION
Closes #519 . This adds support for `dateFormat`, `timestampFormat` options when reading/writing, and generally improves the consistency of inference and parsing.