### PR TITLE
Deprecate Dataset[String] implicit, and XmlReader.withX setters. Add options / schema param to XmlReader constructor.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.4.9
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.2.8
+sbt.version=1.4.9

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -24,41 +24,63 @@ import com.databricks.spark.xml.util.FailFastMode
 /**
  * A collection of static functions for working with XML files in Spark SQL
  */
-class XmlReader extends Serializable {
-  private var parameters = collection.mutable.Map.empty[String, String]
-  private var schema: StructType = null
+class XmlReader(private var schema: StructType,
+                private val options: Map[String, Any]) extends Serializable {
 
+  private val parameters = collection.mutable.Map.empty[String, String]
+  parameters ++= options.mapValues(_.toString)
+
+  // Explicit constructors for Java compatibility
+
+  def this() {
+    this(null, Map.empty)
+  }
+
+  def this(schema: StructType) {
+    this(schema, Map.empty)
+  }
+
+  def this(options: Map[String, Any]) {
+    this(null, options)
+  }
+
+  @deprecated("Use XmlReader(Map) with key 'charset' to specify options", "0.13.0")
   def withCharset(charset: String): XmlReader = {
     parameters += ("charset" -> charset)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'codec' to specify options", "0.13.0")
   def withCompression(codec: String): XmlReader = {
     parameters += ("codec" -> codec)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'rowTag' to specify options", "0.13.0")
   def withRowTag(rowTag: String): XmlReader = {
     parameters += ("rowTag" -> rowTag)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'samplingRatio' to specify options", "0.13.0")
   def withSamplingRatio(samplingRatio: Double): XmlReader = {
     parameters += ("samplingRatio" -> samplingRatio.toString)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'excludeAttribute' to specify options", "0.13.0")
   def withExcludeAttribute(exclude: Boolean): XmlReader = {
     parameters += ("excludeAttribute" -> exclude.toString)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'treatEmptyValuesAsNulls' to specify options", "0.13.0")
   def withTreatEmptyValuesAsNulls(treatAsNull: Boolean): XmlReader = {
     parameters += ("treatEmptyValuesAsNulls" -> treatAsNull.toString)
     this
   }
 
-  @deprecated("Use withParseMode(\"FAILFAST\") instead", "0.10.0")
+  @deprecated("Use XmlReader(Map) with key 'mode' as 'FAILFAST' to specify options", "0.10.0")
   def withFailFast(failFast: Boolean): XmlReader = {
     if (failFast) {
       parameters += ("mode" -> FailFastMode.name)
@@ -68,36 +90,43 @@ class XmlReader extends Serializable {
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'mode' to specify options", "0.13.0")
   def withParseMode(mode: String): XmlReader = {
     parameters += ("mode" -> mode)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'attributePrefix' to specify options", "0.13.0")
   def withAttributePrefix(attributePrefix: String): XmlReader = {
     parameters += ("attributePrefix" -> attributePrefix)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'valueTag' to specify options", "0.13.0")
   def withValueTag(valueTag: String): XmlReader = {
     parameters += ("valueTag" -> valueTag)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'columnNameOfCorruptRecord' to specify options", "0.13.0")
   def withColumnNameOfCorruptRecord(name: String): XmlReader = {
     parameters += ("columnNameOfCorruptRecord" -> name)
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'ignoreSurroundingSpaces' to specify options", "0.13.0")
   def withIgnoreSurroundingSpaces(ignore: Boolean): XmlReader = {
     parameters += ("ignoreSurroundingSpaces" -> ignore.toString)
     this
   }
 
+  @deprecated("Use XmlReader(StructType) to specify schema", "0.13.0")
   def withSchema(schema: StructType): XmlReader = {
     this.schema = schema
     this
   }
 
+  @deprecated("Use XmlReader(Map) with key 'rowValidationXSDPath' to specify options", "0.13.0")
   def withRowValidationXSDPath(path: String): XmlReader = {
     parameters += ("rowValidationXSDPath" -> path)
     this

--- a/src/main/scala/com/databricks/spark/xml/XmlReader.scala
+++ b/src/main/scala/com/databricks/spark/xml/XmlReader.scala
@@ -108,7 +108,8 @@ class XmlReader(private var schema: StructType,
     this
   }
 
-  @deprecated("Use XmlReader(Map) with key 'columnNameOfCorruptRecord' to specify options", "0.13.0")
+  @deprecated("Use XmlReader(Map) with key 'columnNameOfCorruptRecord' to specify options",
+              "0.13.0")
   def withColumnNameOfCorruptRecord(name: String): XmlReader = {
     parameters += ("columnNameOfCorruptRecord" -> name)
     this

--- a/src/main/scala/com/databricks/spark/xml/package.scala
+++ b/src/main/scala/com/databricks/spark/xml/package.scala
@@ -84,6 +84,7 @@ package object xml {
   implicit class XmlDataFrameReader(reader: DataFrameReader) {
     def xml: String => DataFrame = reader.format("com.databricks.spark.xml").load
 
+    @deprecated("Use XmlReader directly", "0.13.0")
     def xml(xmlDataset: Dataset[String]): DataFrame = {
       val spark = SparkSession.builder.getOrCreate()
       new XmlReader().xmlDataset(spark, xmlDataset)

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -232,7 +232,9 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test for permissive mode for corrupt records") {
-    val carsDf = new XmlReader(Map("mode" -> PermissiveMode.name, "columnNameOfCorruptRecord" -> "_malformed_records"))
+    val carsDf = new XmlReader(Map(
+        "mode" -> PermissiveMode.name,
+        "columnNameOfCorruptRecord" -> "_malformed_records"))
       .xmlFile(spark, resDir + "cars-malformed.xml")
     val cars = carsDf.collect()
     assert(cars.length === 3)
@@ -584,9 +586,10 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     // Explicitly set
     val attributePrefix = "@#"
     val valueTag = "#@@value"
-    val resultsTwo =
-      new XmlReader(Map("rowTag" -> "book", "attributePrefix" -> attributePrefix, "valueTag" -> valueTag))
-        .xmlFile(spark, resDir + "books-attributes-in-no-child.xml")
+    val resultsTwo = new XmlReader(Map(
+        "rowTag" -> "book", "attributePrefix" -> attributePrefix,
+        "valueTag" -> valueTag))
+      .xmlFile(spark, resDir + "books-attributes-in-no-child.xml")
 
     val schemaTwo = buildSchema(
       field(s"${attributePrefix}id"),


### PR DESCRIPTION
Closes #527.
See #527 for discussion of the issue.