### PR TITLE
Fix missing value tag crash

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -164,9 +164,9 @@ private[xml] object StaxXmlParser extends Serializable {
         }
         if (attributesOnly) {
           // If everything else is an attribute column, there's no complex structure.
-          // Just return the value of the character element
-          val dt = st.find(_.name == options.valueTag).get.dataType
-          convertTo(c.getData, dt, options)
+          // Just return the value of the character element, or null if we don't have a value tag
+          st.find(_.name == options.valueTag).map(
+            valueTag => convertTo(c.getData, valueTag.dataType, options)).orNull
         } else {
           // Otherwise, ignore this character element, and continue parsing the following complex
           // structure

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -1185,6 +1185,16 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(whitespaceDF.take(1).head.getAs[String]("_corrupt_record") !== null)
   }
 
+  test("struct with only attributes and no value tag does not crash") {
+    val schema = buildSchema(struct("book", field("_id", StringType)), field("_corrupt_record"))
+    val booksDF = spark.read
+      .option("rowTag", "book")
+      .schema(schema)
+      .xml(resDir + "books.xml")
+
+    assert(booksDF.count() === 12)
+  }
+
   test("XML in String field preserves attributes") {
     val schema = buildSchema(field("ROW"))
     val result = spark.read


### PR DESCRIPTION
**Before this PR:** the attached test would crash because we're not providing a valueTag in our struct schema. This is a regression from a previous version, where this was simply ignored.

**After this PR:** character element is ignored instead when there is no value tag.