### PR TITLE
Return null for primitive types when value matches nullValue string

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -46,11 +46,9 @@ private[xml] object TypeCast {
   private[xml] def castTo(
       datum: String,
       castType: DataType,
-      options: XmlOptions,
-      nullable: Boolean = true): Any = {
-    if (datum == options.nullValue &&
-      nullable ||
-      (options.treatEmptyValuesAsNulls && datum == "")){
+      options: XmlOptions): Any = {
+    if ((datum == options.nullValue) ||
+        (options.treatEmptyValuesAsNulls && datum == "")) {
       null
     } else {
       castType match {
@@ -140,21 +138,26 @@ private[xml] object TypeCast {
     } else {
       datum
     }
-    dataType match {
-      case NullType => castTo(value, StringType, options)
-      case LongType => signSafeToLong(value, options)
-      case DoubleType => signSafeToDouble(value, options)
-      case BooleanType => castTo(value, BooleanType, options)
-      case StringType => castTo(value, StringType, options)
-      case DateType => castTo(value, DateType, options)
-      case TimestampType => castTo(value, TimestampType, options)
-      case FloatType => signSafeToFloat(value, options)
-      case ByteType => castTo(value, ByteType, options)
-      case ShortType => castTo(value, ShortType, options)
-      case IntegerType => signSafeToInt(value, options)
-      case dt: DecimalType => castTo(value, dt, options)
-      case _ => throw new IllegalArgumentException(
-        s"Failed to parse a value for data type $dataType.")
+    if ((value == options.nullValue) ||
+      (options.treatEmptyValuesAsNulls && value == "")) {
+      null
+    } else {
+      dataType match {
+        case NullType => castTo(value, StringType, options)
+        case LongType => signSafeToLong(value, options)
+        case DoubleType => signSafeToDouble(value, options)
+        case BooleanType => castTo(value, BooleanType, options)
+        case StringType => castTo(value, StringType, options)
+        case DateType => castTo(value, DateType, options)
+        case TimestampType => castTo(value, TimestampType, options)
+        case FloatType => signSafeToFloat(value, options)
+        case ByteType => castTo(value, ByteType, options)
+        case ShortType => castTo(value, ShortType, options)
+        case IntegerType => signSafeToInt(value, options)
+        case dt: DecimalType => castTo(value, dt, options)
+        case _ => throw new IllegalArgumentException(
+          s"Failed to parse a value for data type $dataType.")
+      }
     }
   }
 

--- a/src/test/resources/null-numbers-2.xml
+++ b/src/test/resources/null-numbers-2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<TEST>
+    <Header Name="X" SequenceNumber="123"/>
+    <T Number="1" Volume="20"/>
+    <T Number="2" Volume=""/>
+</TEST>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -34,6 +34,7 @@ import com.databricks.spark.xml.XmlOptions._
 import com.databricks.spark.xml.functions._
 import com.databricks.spark.xml.util._
 
+import org.apache.spark.sql.functions.{explode, column}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.SparkException
@@ -1346,6 +1347,22 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
       buildSchema(field("author"), field("time", TimestampType), field("time2", TimestampType))
     assert(df.schema === expectedSchema)
     assert(df.collect().head.getAs[Timestamp](2).getTime === 1322936130000L)
+  }
+
+  test("Test null number type is null not 0.0") {
+    val schema = buildSchema(
+      struct("Header",
+        field("_Name"), field("_SequenceNumber", LongType)),
+      structArray("T",
+        field("_Number", LongType), field("_VALUE", DoubleType), field("_Volume", DoubleType)))
+
+    val df = spark.read.option("rowTag", "TEST")
+      .option("nullValue", "")
+      .schema(schema)
+      .xml(resDir + "null-numbers-2.xml")
+      .select(explode(column("T")))
+
+    assert(df.collect()(1).getStruct(0).get(2) === null)
   }
 
   private def getLines(path: Path): Seq[String] = {

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -52,14 +52,6 @@ final class TypeCastSuite extends AnyFunSuite {
     assert(TypeCast.castTo("", StringType, options) === "")
   }
 
-  test("Throws exception for empty string with non null type") {
-    val options = new XmlOptions()
-    val exception = intercept[NumberFormatException]{
-      TypeCast.castTo("", IntegerType, options, nullable = false)
-    }
-    assert(exception.getMessage.contains("For input string: \"\""))
-  }
-
   test("Types are cast correctly") {
     val options = new XmlOptions()
     assert(TypeCast.castTo("10", ByteType, options) === 10)


### PR DESCRIPTION
Closes #540 

While the code did handle detection of input matching the `nullValue` and returning null, in paths where the column type was a primitive in Java like `DoubleType`, the cast turned it into 0.0. This adds additional checking to perform the same check earlier.