### PR TITLE
Change $default_branch to static branches (and set Java version correctly)

### DIFF
--- a/.github/workflows/test_spark_2_java_8.yml
+++ b/.github/workflows/test_spark_2_java_8.yml
@@ -1,9 +1,9 @@
 name: Spark 2 / Java 8
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [master]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_spark_2_java_8.yml
+++ b/.github/workflows/test_spark_2_java_8.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Set up Java, SBT
         uses: olafurpg/setup-scala@v11
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: 'adopt@1.8'
       - name: Build and test
         run: sbt -Dspark.testVersion=2.4.8 ++2.11.12 clean scalastyle test:scalastyle mimaReportBinaryIssues test

--- a/.github/workflows/test_spark_3_java_11.yml
+++ b/.github/workflows/test_spark_3_java_11.yml
@@ -1,9 +1,9 @@
 name: Spark 3 / Java 11
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [master]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_spark_3_java_11.yml
+++ b/.github/workflows/test_spark_3_java_11.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Set up Java, SBT
         uses: olafurpg/setup-scala@v11
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: 'adopt@1.11'
       - name: Build and test
         run: sbt -Dspark.testVersion=3.1.2 ++2.12.10 clean scalastyle test:scalastyle mimaReportBinaryIssues coverage test coverageReport
       - name: Check code coverage


### PR DESCRIPTION
This PR proposes to use:
- static branches instead of `$default-branch` that's to be used as a template.
- use `adopt@1.8` syntax (as documented in https://github.com/olafurpg/setup-scala). Otherwise it picks JDK 11 for `java-version: '8'`.