### PR TITLE
Support XSD schema complexType with only attributes; with value but no type too (assume string)

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -193,14 +193,20 @@ object XSDToSchema {
                       throw new IllegalArgumentException(s"Unsupported item: $unsupported")
                     }
                   }.toSeq
+                case null =>
+                  Seq.empty
                 case unsupported =>
                   throw new IllegalArgumentException(s"Unsupported particle: $unsupported")
               }
             val attributes = complexType.getAttributes.asScala.map {
               case attribute: XmlSchemaAttribute =>
-                val baseStructField = getStructField(xmlSchema,
-                  xmlSchema.getParent.getTypeByQName(attribute.getSchemaTypeName))
-                StructField(s"_${attribute.getName}", baseStructField.dataType,
+                val attributeType = attribute.getSchemaTypeName match {
+                  case null =>
+                    StringType
+                  case t =>
+                    getStructField(xmlSchema, xmlSchema.getParent.getTypeByQName(t)).dataType
+                }
+                StructField(s"_${attribute.getName}", attributeType,
                   attribute.getUse != XmlSchemaUse.REQUIRED)
             }.toSeq
             StructField(complexType.getName, StructType(childFields ++ attributes))


### PR DESCRIPTION
Pretty much as it says. This supports cases like:

```
	<xs:complexType name="foo">
		<xs:attribute name="bar" type="bing" use="required"/>
		<xs:attribute name="baz" type="buzz" use="required"/>
	</xs:complexType>
```

and

```
	<xs:complexType name="foo">
		<xs:attribute name="bar" fixed="X" use="required"/>
	</xs:complexType>
```