### PR TITLE
use codecov-action

### DIFF
--- a/.github/workflows/test_spark_3_java_8.yml
+++ b/.github/workflows/test_spark_3_java_8.yml
@@ -16,4 +16,6 @@ jobs:
       - name: Build and test
         run: sbt -Dspark.testVersion=3.0.3 ++2.12.10 clean scalastyle test:scalastyle mimaReportBinaryIssues coverage test coverageReport
       - name: Check code coverage
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
The bash based uploader for codecov is deprecated and will soon start browning out.

codecov-action v2 uses the newer uploader.

The bash based v1 uploader was blamed for a security breach - https://www.zdnet.com/article/codecov-breach-impacted-hundreds-of-customer-networks/