### PR TITLE
Fix Python documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ df.select("author", "_id").write()
 
 ```python
 from pyspark.sql import SparkSession
-spark = SparkSession.builder().getOrCreate()
+spark = SparkSession.builder.getOrCreate()
 
 df = spark.read.format('xml').options(rowTag='book').load('books.xml')
 df.select("author", "_id").write \
@@ -372,7 +372,7 @@ You can manually specify schema:
 from pyspark.sql import SparkSession
 from pyspark.sql.types import *
 
-spark = SparkSession.builder().getOrCreate()
+spark = SparkSession.builder.getOrCreate()
 customSchema = StructType([
     StructField("_id", StringType(), True),
     StructField("author", StringType(), True),


### PR DESCRIPTION
Fixes error in Python documentation on the readme by removing the `()` since builder is not callable