### PR TITLE
Fix is for XSD having the decimal data type with restriction

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -86,7 +86,10 @@ object XSDToSchema {
       case simpleType: XmlSchemaSimpleType =>
         val schemaType = simpleType.getContent match {
           case restriction: XmlSchemaSimpleTypeRestriction =>
-            simpleType.getQName match {
+            val qName = if (simpleType.getQName !=null) {
+              simpleType.getQName
+            } else restriction.getBaseTypeName
+            qName match {
               case Constants.XSD_BOOLEAN => BooleanType
               case Constants.XSD_DECIMAL =>
                 val scale = restriction.getFacets.asScala.collectFirst {

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -86,8 +86,9 @@ object XSDToSchema {
       case simpleType: XmlSchemaSimpleType =>
         val schemaType = simpleType.getContent match {
           case restriction: XmlSchemaSimpleTypeRestriction =>
-            val qName = simpleType.getQName match { case null => restriction.getBaseTypeName
-              case _ => simpleType.getQName
+            val qName = simpleType.getQName match {
+              case null => restriction.getBaseTypeName
+              case n => n
             }
             qName match {
               case Constants.XSD_BOOLEAN => BooleanType

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -86,9 +86,10 @@ object XSDToSchema {
       case simpleType: XmlSchemaSimpleType =>
         val schemaType = simpleType.getContent match {
           case restriction: XmlSchemaSimpleTypeRestriction =>
-            val qName = if (simpleType.getQName !=null) {
-              simpleType.getQName
-            } else restriction.getBaseTypeName
+            val qName = simpleType.getQName match {
+              case null => restriction.getBaseTypeName
+              case _ => simpleType.getQName
+            }
             qName match {
               case Constants.XSD_BOOLEAN => BooleanType
               case Constants.XSD_DECIMAL =>

--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -86,8 +86,7 @@ object XSDToSchema {
       case simpleType: XmlSchemaSimpleType =>
         val schemaType = simpleType.getContent match {
           case restriction: XmlSchemaSimpleTypeRestriction =>
-            val qName = simpleType.getQName match {
-              case null => restriction.getBaseTypeName
+            val qName = simpleType.getQName match { case null => restriction.getBaseTypeName
               case _ => simpleType.getQName
             }
             qName match {

--- a/src/test/resources/decimal-with-restriction.xsd
+++ b/src/test/resources/decimal-with-restriction.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="decimal_type_1" type="xs:decimal"/>
+  <xs:element name="decimal_type_2">
+    <xs:simpleType>
+      <xs:restriction base="xs:decimal">
+        <xs:fractionDigits value="2" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -17,10 +17,8 @@
 package com.databricks.spark.xml.util
 
 import java.nio.file.Paths
-
-import org.apache.spark.sql.types.{ArrayType, FloatType, LongType, StringType}
+import org.apache.spark.sql.types.{ArrayType, DecimalType, FloatType, LongType, StringType}
 import org.scalatest.funsuite.AnyFunSuite
-
 import com.databricks.spark.xml.TestUtils._
 
 class XSDToSchemaSuite extends AnyFunSuite {
@@ -116,6 +114,13 @@ class XSDToSchemaSuite extends AnyFunSuite {
       field("test",
         struct(field("userId", LongType, nullable = false)), nullable = false))
     assert(expectedSchema === parsedSchema)
+  }
+
+  test("decimal-with-restriction") {
+    val parsedSchema = XSDToSchema.read(Paths.get(s"$resDir/decimal-with-restriction.xsd"))
+    val expectedSchema = buildSchema(field("decimal_type_1", DecimalType(38, 18), nullable = false),
+      field("decimal_type_2", DecimalType(38, 2), nullable = false))
+    assert(parsedSchema === expectedSchema)
   }
 
 }

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -17,8 +17,10 @@
 package com.databricks.spark.xml.util
 
 import java.nio.file.Paths
+
 import org.apache.spark.sql.types.{ArrayType, DecimalType, FloatType, LongType, StringType}
 import org.scalatest.funsuite.AnyFunSuite
+
 import com.databricks.spark.xml.TestUtils._
 
 class XSDToSchemaSuite extends AnyFunSuite {
@@ -116,7 +118,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
     assert(expectedSchema === parsedSchema)
   }
 
-  test("decimal-with-restriction") {
+  test("Test xs:decimal type with restriction[fractionalDigits]") {
     val parsedSchema = XSDToSchema.read(Paths.get(s"$resDir/decimal-with-restriction.xsd"))
     val expectedSchema = buildSchema(field("decimal_type_1", DecimalType(38, 18), nullable = false),
       field("decimal_type_2", DecimalType(38, 2), nullable = false))


### PR DESCRIPTION
This code fix is for XSD having the decimal data type with restriction. XSDToSchema util class returns the StringType if the XSD has the decimal data type with restriction. 