### PR TITLE
Clone HadoopConf to avoid cross usage of tags while parsing the xml

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XmlFile.scala
@@ -23,6 +23,7 @@ import scala.collection.Map
 
 import com.databricks.spark.xml.parsers.StaxXmlGenerator
 import com.sun.xml.txw2.output.IndentingXMLStreamWriter
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{Text, LongWritable}
 
 import org.apache.spark.rdd.RDD
@@ -40,13 +41,15 @@ private[xml] object XmlFile {
       rowTag: String): RDD[String] = {
     // This just checks the charset's validity early, to keep behavior
     Charset.forName(charset)
-    context.hadoopConfiguration.set(XmlInputFormat.START_TAG_KEY, s"<$rowTag>")
-    context.hadoopConfiguration.set(XmlInputFormat.END_TAG_KEY, s"</$rowTag>")
-    context.hadoopConfiguration.set(XmlInputFormat.ENCODING_KEY, charset)
+    val config = new Configuration(context.hadoopConfiguration)
+    config.set(XmlInputFormat.START_TAG_KEY, s"<$rowTag>")
+    config.set(XmlInputFormat.END_TAG_KEY, s"</$rowTag>")
+    config.set(XmlInputFormat.ENCODING_KEY, charset)
     context.newAPIHadoopFile(location,
       classOf[XmlInputFormat],
       classOf[LongWritable],
-      classOf[Text]).map { case (_, text) => text.toString }
+      classOf[Text],
+      config).map { case (_, text) => text.toString }
   }
 
   /**


### PR DESCRIPTION
This code is to fix the issue 581.

Added unit tests and also verified manually by using below code
```
import scala.collection.JavaConverters._
import scala.collection.mutable
val jobGroudId_ages = mutable.Set[Long]()

val threads_ages = (1001 to 1010).map { i =>
  new Thread {
    override def run() {
      sc.setJobGroup(s"$i", s"$i")
      val df = spark.read.option("rowTag", "person").format("xml").load("file:/Users/XXXX/spark-xml/src/test/resources/ages.xml") 
      if(df.schema.fields.isEmpty) {
        println(s"found repro for the ages run $i **********************")
        jobGroudId_ages.add(i)
      }
    }
  }
}


import scala.collection.JavaConverters._
import scala.collection.mutable
val jobGroudId_books = mutable.Set[Long]()

val threads = (1 to 10).map { i =>
  new Thread {
    override def run() {
      sc.setJobGroup(s"$i", s"$i")
      val df = spark.read.option("rowTag", "book").format("xml").load("file:/Users/XXXX/spark-xml/src/test/resources/books.xml") 
      if(df.schema.fields.isEmpty) {
        println(s"found repro for the book run $i **********************")
        jobGroudId_books.add(i)
      }
    }
  }
}

threads_ages.foreach(_.start())
threads.foreach(_.start())
threads_ages.foreach(_.join())
threads.foreach(_.join())
println(s" jobGroudId_books is ${jobGroudId_books.size} ")
println(s" jobGroudId_ages is ${jobGroudId_ages.size} ")
```


**Before fix**
<img width="484" alt="image" src="https://user-images.githubusercontent.com/70568553/171571832-3d71f478-1503-4e68-ae86-335d04e03577.png">

**After fix**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/70568553/171572039-b5c4b8f4-2544-4f34-8a23-9fade0944453.png">
