### PR TITLE
Simplify handling of complex mixed elements when schema says it is a string; should always just repeat the content as string

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -173,6 +173,8 @@ private[xml] object StaxXmlParser extends Serializable {
             case _ => convertObject(parser, st, options)
           }
         }
+      case (_: Characters, _: StringType) =>
+        StaxXmlParserUtils.currentStructureAsString(parser)
       case (c: Characters, _: DataType) if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide
         // if this is really data or space between other elements.

--- a/src/test/resources/mixed_children_as_string.xml
+++ b/src/test/resources/mixed_children_as_string.xml
@@ -1,0 +1,9 @@
+<books>
+    <book>
+        <text>
+            Lorem ipsum dolor sit amet. Ut <i>voluptas</i> distinctio et impedit deserunt aut quam fugit et quaerat odit et nesciunt earum non dolores culpa et sunt nobis. Aut accusamus iste sed odio debitis et quasi amet rem quam sequi et voluptatem placeat aut voluptates iste? Vel nisi rerum sit eligendi excepturi et galisum animi et ipsa nihil vel consequatur velit eos velit nesciunt.
+            Quo voluptatibus sint ab officiis aperiam non obcaecati rerum eos veniam iste eum ipsam modi. <i>Non</i> voluptatem illum qui molestiae magni qui maxime commodi et accusantium similique qui necessitatibus <i>minus</i>?
+            At quod rerum et porro nisi ut tempore error et enim optio cum Quis voluptatibus qui dolores sapiente cum cupiditate quia. Ut incidunt neque aut provident quaerat qui quia <i>illum</i>. Ab esse commodi ad earum molestias non internos atque non <i>consequatur</i> inventore 33 galisum nobis hic distinctio impedit! Est dicta iusto est <i>numquam</i> incidunt cum autem temporibus.
+        </text>
+    </book>
+</books>


### PR DESCRIPTION
Closes #614 