### PR TITLE
Parse complexContent with extension element

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/XSDToSchema.scala
@@ -145,7 +145,7 @@ object XSDToSchema {
                 val baseStructField = getStructField(xmlSchema,
                   xmlSchema.getParent.getTypeByQName(extension.getBaseTypeName))
                 val baseFields = baseStructField.dataType match {
-                  case structType @ StructType(_) => structType.fields
+                  case structType: StructType => structType.fields
                   case others =>
                     throw new IllegalArgumentException(
                       s"Non-StructType in ComplexContentExtension: $others"

--- a/src/test/resources/complex-content-extension.xsd
+++ b/src/test/resources/complex-content-extension.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="employee" type="fullpersoninfo"/>
+
+<xs:complexType name="personinfo">
+  <xs:sequence>
+    <xs:element name="firstname" type="xs:string"/>
+    <xs:element name="lastname" type="xs:string"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="fullpersoninfo">
+  <xs:complexContent>
+    <xs:extension base="personinfo">
+      <xs:sequence>
+        <xs:element name="address" type="xs:string"/>
+        <xs:element name="city" type="xs:string"/>
+        <xs:element name="country" type="xs:string"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+</xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -153,7 +153,7 @@ class XSDToSchemaSuite extends AnyFunSuite {
     assert(parsedSchema === expectedSchema)
   }
 
-  test("Test complex content with extension element") {
+  test("Test complex content with extension element / Issue 554") {
     val parsedSchema = XSDToSchema.read(Paths.get(s"$resDir/complex-content-extension.xsd"))
 
     val expectedSchema = buildSchema(

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -152,4 +152,23 @@ class XSDToSchemaSuite extends AnyFunSuite {
     )
     assert(parsedSchema === expectedSchema)
   }
+
+  test("Test complex content with extension element") {
+    val parsedSchema = XSDToSchema.read(Paths.get(s"$resDir/complex-content-extension.xsd"))
+
+    val expectedSchema = buildSchema(
+      field(
+        "employee",
+        struct(
+          field("firstname", StringType, false),
+          field("lastname", StringType, false),
+          field("address", StringType, false),
+          field("city", StringType, false),
+          field("country", StringType, false)
+        ),
+        false
+      )
+    )
+    assert(parsedSchema === expectedSchema)
+  }
 }


### PR DESCRIPTION
Resolves an issue reported in https://github.com/databricks/spark-xml/issues/554

- adding the capability to parse extension element in complexContent