### PR TITLE
Restore functionality of ignoreSurroundingSpaces when field is a simple string

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -136,7 +136,8 @@ private[xml] object StaxXmlParser extends Serializable {
       case st: StructType => convertObject(parser, st, options)
       case MapType(StringType, vt, _) => convertMap(parser, vt, options, attributes)
       case ArrayType(st, _) => convertField(parser, st, options)
-      case _: StringType => StaxXmlParserUtils.currentStructureAsString(parser)
+      case _: StringType =>
+        convertTo(StaxXmlParserUtils.currentStructureAsString(parser), StringType, options)
     }
 
     (parser.peek, dataType) match {
@@ -174,7 +175,7 @@ private[xml] object StaxXmlParser extends Serializable {
           }
         }
       case (_: Characters, _: StringType) =>
-        StaxXmlParserUtils.currentStructureAsString(parser)
+        convertTo(StaxXmlParserUtils.currentStructureAsString(parser), StringType, options)
       case (c: Characters, _: DataType) if c.isWhiteSpace =>
         // When `Characters` is found, we need to look further to decide
         // if this is really data or space between other elements.

--- a/src/test/resources/feed-with-spaces.xml
+++ b/src/test/resources/feed-with-spaces.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed>
+    <entry>
+        <id>A</id>
+    </entry>
+    <entry>
+        <id> B</id>
+    </entry>
+    <entry>
+        <id>C </id>
+    </entry>
+    <entry>
+        <id> D </id>
+    </entry>
+</feed>

--- a/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/XmlSuite.scala
@@ -903,7 +903,17 @@ final class XmlSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(resultsTwo.collect().length === 2)
   }
 
-  test("ignoreSurroundingSpaces test") {
+  test("ignoreSurroundingSpace with string types") {
+    val df = spark.read
+      .option("inferSchema", true)
+      .option("rowTag", "entry")
+      .option("ignoreSurroundingSpaces", true)
+      .xml(resDir + "feed-with-spaces.xml")
+    val results = df.collect().map(_.getString(0))
+    assert(results === Array("A", "B", "C", "D"))
+  }
+
+  test("ignoreSurroundingSpaces with non-string types") {
     val results = new XmlReader(Map("ignoreSurroundingSpaces" -> true, "rowTag" -> "person"))
       .xmlFile(spark, resDir + "ages-with-spaces.xml")
       .collect()


### PR DESCRIPTION
At some point, strings stopped going through the convertTo() path, and that's what handles ignoreSurroundingSpaces.
Fixes https://github.com/databricks/spark-xml/issues/636