### PR TITLE
In XSD, handle frac digits for decimal types. Also try to support custom type declarations in the XSD

### DIFF
--- a/src/test/resources/decimal-with-restriction.xsd
+++ b/src/test/resources/decimal-with-restriction.xsd
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="somedecimal">
+    <xs:restriction base="xs:decimal">
+      <xs:fractionDigits value="6"/>
+      <xs:totalDigits value="12"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:element name="decimal_type_1" type="xs:decimal"/>
   <xs:element name="decimal_type_2">
     <xs:simpleType>
@@ -8,4 +14,5 @@
       </xs:restriction>
     </xs:simpleType>
   </xs:element>
+  <xs:element name="decimal_type_3" type="somedecimal"/>
 </xs:schema>

--- a/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/XSDToSchemaSuite.scala
@@ -115,13 +115,16 @@ class XSDToSchemaSuite extends AnyFunSuite {
     val expectedSchema = buildSchema(
       field("test",
         struct(field("userId", LongType, nullable = false)), nullable = false))
-    assert(expectedSchema === parsedSchema)
+    assert(parsedSchema === expectedSchema)
   }
 
   test("Test xs:decimal type with restriction[fractionalDigits]") {
     val parsedSchema = XSDToSchema.read(Paths.get(s"$resDir/decimal-with-restriction.xsd"))
-    val expectedSchema = buildSchema(field("decimal_type_1", DecimalType(38, 18), nullable = false),
-      field("decimal_type_2", DecimalType(38, 2), nullable = false))
+    val expectedSchema = buildSchema(
+      field("decimal_type_3", DecimalType(12, 6), nullable = false),
+      field("decimal_type_1", DecimalType(38, 18), nullable = false),
+      field("decimal_type_2", DecimalType(38, 2), nullable = false)
+    )
     assert(parsedSchema === expectedSchema)
   }
 


### PR DESCRIPTION
Two things:

Support frac digits, not just scale, in XSD schemas when reading XSDs as schema.

Also, try to support simple named types in the XSD along the way.