### PR TITLE
Disallow strings ending in D or F as doubles when inferring schema

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -196,6 +196,13 @@ private[xml] object TypeCast {
     } else {
       value
     }
+    // Rule out strings ending in D or F, as they will parse as double but should be disallowed
+    if (value.nonEmpty && (value.last match {
+          case 'd' | 'D' | 'f' | 'F' => true
+          case _ => false
+        })) {
+      return false
+    }
     (allCatch opt signSafeValue.toDouble).isDefined
   }
 

--- a/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/xml/util/TypeCastSuite.scala
@@ -147,6 +147,8 @@ final class TypeCastSuite extends AnyFunSuite {
     assert(TypeCast.isInteger("10"))
     assert(TypeCast.isLong("10"))
     assert(TypeCast.isDouble("+10.1"))
+    assert(!TypeCast.isDouble("8E9D"))
+    assert(!TypeCast.isDouble("8E9F"))
     val timestamp = "2015-01-01 00:00:00"
     assert(TypeCast.isTimestamp(timestamp, new XmlOptions()))
   }


### PR DESCRIPTION
Closes https://github.com/databricks/spark-xml/issues/643