### PR TITLE
Shortcut common type inference cases to fail fast, speed up inference

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/xml/util/TypeCast.scala
@@ -213,6 +213,12 @@ private[xml] object TypeCast {
     } else {
       value
     }
+    // A little shortcut to avoid trying many formatters in the common case that
+    // the input isn't a double. All built-in formats will start with a digit or period.
+    if (signSafeValue.isEmpty ||
+        !(Character.isDigit(signSafeValue.head) || signSafeValue.head == '.')) {
+      return false
+    }
     // Rule out strings ending in D or F, as they will parse as double but should be disallowed
     if (value.nonEmpty && (value.last match {
           case 'd' | 'D' | 'f' | 'F' => true
@@ -229,6 +235,11 @@ private[xml] object TypeCast {
     } else {
       value
     }
+    // A little shortcut to avoid trying many formatters in the common case that
+    // the input isn't a number. All built-in formats will start with a digit.
+    if (signSafeValue.isEmpty || !Character.isDigit(signSafeValue.head)) {
+      return false
+    }
     (allCatch opt signSafeValue.toInt).isDefined
   }
 
@@ -237,6 +248,11 @@ private[xml] object TypeCast {
       value.substring(1)
     } else {
       value
+    }
+    // A little shortcut to avoid trying many formatters in the common case that
+    // the input isn't a number. All built-in formats will start with a digit.
+    if (signSafeValue.isEmpty || !Character.isDigit(signSafeValue.head)) {
+      return false
     }
     (allCatch opt signSafeValue.toLong).isDefined
   }


### PR DESCRIPTION
In schema inference, many different types are tried out for each input. This can get really slow in some cases, especially where the true type is just 'string'. This adds several shortcuts in the type inference code, to fail fast before expensive parsing code is run, where it's clear the parsing won't work. This also avoids using a thrown exception in one case for better speed.