### PR TITLE
Fix for xml expression to not parse arbitrary strings

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/functions.scala
+++ b/src/main/scala/com/databricks/spark/xml/functions.scala
@@ -17,7 +17,6 @@
 package com.databricks.spark.xml
 
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.types.DataType
 
 /**
@@ -28,14 +27,13 @@ object functions {
   /**
    * Parses a column containing a XML string into a `StructType` with the specified schema.
    *
-   * @param e a string column containing XML data
+   * @param col a string column containing XML data
    * @param schema the schema to use when parsing the XML string. Must be a StructType if
    *   column is string-valued, or ArrayType[StructType] if column is an array of strings
    * @param options key-value pairs that correspond to those supported by [[XmlOptions]]
    */
-  def from_xml(e: Column, schema: DataType, options: Map[String, String] = Map.empty): Column = {
-    val expr = CatalystSqlParser.parseExpression(e.toString())
-    new Column(XmlDataToCatalyst(expr, schema, XmlOptions(options)))
+  def from_xml(col: Column, schema: DataType, options: Map[String, String] = Map.empty): Column = {
+    new Column(XmlDataToCatalyst(col.expr, schema, XmlOptions(options)))
   }
 
 }


### PR DESCRIPTION
Previously it was the case that we would parse the string of the column as the column expression argument for the expression. This leads to being able to execute arbitrary spark SQL if you parse the expression a string literal. It also means that string literals don't work with this expression and it doesn't work within an array transform expression either.