### PR TITLE
Fix Scala ArrayBuffer cast to Spark ArrayData for Scala 2.13

### DIFF
--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -320,15 +320,15 @@ private[xml] object StaxXmlParser extends Serializable {
 
               case ArrayType(dt: DataType, _) =>
                 val values = Option(row(index))
-                  .map(_.asInstanceOf[Array[Any]])
-                  .getOrElse(Array.empty[Any])
+                  .map(_.asInstanceOf[ArrayBuffer[Any]])
+                  .getOrElse(ArrayBuffer.empty[Any])
                 val newValue = dt match {
                   case st: StructType =>
                     convertObjectWithAttributes(parser, st, options, attributes)
                   case dt: DataType =>
                     convertField(parser, dt, options)
                 }
-                row(index) = values :+ newValue
+                row(index) = (values :+ newValue).toArray
 
               case dt: DataType =>
                 row(index) = convertField(parser, dt, options, attributes)
@@ -345,9 +345,9 @@ private[xml] object StaxXmlParser extends Serializable {
                     row(anyIndex) = newValue
                   case ArrayType(StringType, _) =>
                     val values = Option(row(anyIndex))
-                      .map(_.asInstanceOf[Array[String]])
-                      .getOrElse(Array.empty[String])
-                    row(anyIndex) = values :+ newValue
+                      .map(_.asInstanceOf[ArrayBuffer[String]])
+                      .getOrElse(ArrayBuffer.empty[String])
+                    row(anyIndex) = (values :+ newValue).toArray
                 }
               } else {
                 StaxXmlParserUtils.skipChildren(parser)

--- a/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
+++ b/src/main/scala/com/databricks/spark/xml/parsers/StaxXmlParser.scala
@@ -320,8 +320,8 @@ private[xml] object StaxXmlParser extends Serializable {
 
               case ArrayType(dt: DataType, _) =>
                 val values = Option(row(index))
-                  .map(_.asInstanceOf[ArrayBuffer[Any]])
-                  .getOrElse(ArrayBuffer.empty[Any])
+                  .map(_.asInstanceOf[Array[Any]])
+                  .getOrElse(Array.empty[Any])
                 val newValue = dt match {
                   case st: StructType =>
                     convertObjectWithAttributes(parser, st, options, attributes)
@@ -345,8 +345,8 @@ private[xml] object StaxXmlParser extends Serializable {
                     row(anyIndex) = newValue
                   case ArrayType(StringType, _) =>
                     val values = Option(row(anyIndex))
-                      .map(_.asInstanceOf[ArrayBuffer[String]])
-                      .getOrElse(ArrayBuffer.empty[String])
+                      .map(_.asInstanceOf[Array[String]])
+                      .getOrElse(Array.empty[String])
                     row(anyIndex) = values :+ newValue
                 }
               } else {


### PR DESCRIPTION
Closes #688

Fix problem with cast scala.collection.mutable.ArrayBuffer to org.apache.spark.sql.catalyst.util.ArrayData